### PR TITLE
QH - DSPDC-992 - Create ValueSet for Brain Cell Types

### DIFF
--- a/src/references/pCL_4.owl.rdf
+++ b/src/references/pCL_4.owl.rdf
@@ -1,0 +1,8928 @@
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // pCL_4.owl - File obtained from https://bioportal.bioontology.org/ontologies/PCL
+    // Released: 04/26/2020
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.jcvi.org/framework/nsf2_full_mtg#"
+     xml:base="http://www.jcvi.org/framework/nsf2_full_mtg"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:DEFAULT="http://www.jcvi.org/framework/nsf2_full_mtg">
+    <owl:Ontology rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg">
+        <owl:versionIRI rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg/4.0.0"/>
+        <owl:versionInfo>$Id: pcl_4_0.owl, Ver 1.0, April 12, 2020, Brian Aevermann $</owl:versionInfo>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000100 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/PCL_0000100">
+        <rdfs:label>synonym</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#has_soma_location_in -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#has_soma_location_in"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#id -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#id"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#neuron_type -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#neuron_type"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#part_of -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#part_of"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#preferred_name -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#preferred_name"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#prefixIRI -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#prefixIRI"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#species_id -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#species_id"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#species_source -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#species_source"/>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#tdc_id -->
+
+    <owl:AnnotationProperty rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#tdc_id"/>
+    
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#definition -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000881 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000881">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129"/>
+        <id>CL_0000881</id>
+        <preferred_name>perivascular macrophage</preferred_name>
+        <prefixIRI>CL_0000881</prefixIRI>
+        <rdfs:label>perivascular macrophage</rdfs:label>
+        <skos:definition>A central nervous system macrophage found in small blood vessels in the brain. Markers include CD14+CD16+CD163+.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097"/>
+        <id>pCL_0000</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MEIS2-expressing primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000</prefixIRI>
+        <rdfs:label>MEIS2-expressing primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a MEIS2-expressing primary motor cortex GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000101">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000364"/>
+        <obo:PCL_0000100>Meis2</obo:PCL_0000100>
+        <id>pCL_00000291</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Meis2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000291</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken191</tdc_id>
+        <rdfs:label>Meis2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Meis2-expressing mouse primary motor cortex Meis2 glutamatergic neuron that selectively expresses Meis2, and Tiam2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000102 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000102">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000364"/>
+        <obo:PCL_0000100>Meis2_Top2a</obo:PCL_0000100>
+        <id>pCL_00000292</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Igfbpl1-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000292</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken192</tdc_id>
+        <rdfs:label>Igfbpl1-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Igfbpl1-expressing mouse primary motor cortex Meis2 glutamatergic glutamatergic neuron that selectively expresses Gm17750, and Gm29260, and Igfbpl1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000105">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000105</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 2/3 Intratelencephalic neuron</preferred_name>
+        <prefixIRI>pCL:00000105</prefixIRI>
+        <rdfs:label>Layer 2/3 Intratelencephalic neuron</rdfs:label>
+        <skos:definition>is a Layer 2/3 Intratelencephalic neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000106 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000106">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <id>pCL_00000106</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 5 Extratelencephalic neuron</preferred_name>
+        <prefixIRI>pCL:00000106</prefixIRI>
+        <rdfs:label>Layer 5 Extratelencephalic neuron</rdfs:label>
+        <skos:definition>is a Layer 5 Extratelencephalic neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000107 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000107">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000107</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 5 Intratelencephalic neuron</preferred_name>
+        <prefixIRI>pCL:00000107</prefixIRI>
+        <rdfs:label>Layer 5 Intratelencephalic neuron</rdfs:label>
+        <skos:definition>is a Layer 5 Intratelencephalic neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000108 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000108">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000108</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>layer 5/6 non-pyramidal neuron</preferred_name>
+        <prefixIRI>pCL:00000108</prefixIRI>
+        <rdfs:label>layer 5/6 non-pyramidal neuron</rdfs:label>
+        <skos:definition>is a layer 5/6 non-pyramidal neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000109 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000109">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000109</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 6 Corticothalamic neuron</preferred_name>
+        <prefixIRI>pCL:00000109</prefixIRI>
+        <rdfs:label>Layer 6 Corticothalamic neuron</rdfs:label>
+        <skos:definition>is a Layer 6 Corticothalamic neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000110 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000110">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000110</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 6 Intratelencephalic neuron that selectively expresses Car3</preferred_name>
+        <prefixIRI>pCL:00000110</prefixIRI>
+        <tdc_id>Bakken59</tdc_id>
+        <rdfs:label>Layer 6 Intratelencephalic neuron that selectively expresses Car3</rdfs:label>
+        <skos:definition>is a Layer 6 Intratelencephalic neuron that selectively expresses Car3</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000111 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000111">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000111</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 6 Intratelencephalic neuron</preferred_name>
+        <prefixIRI>pCL:00000111</prefixIRI>
+        <rdfs:label>Layer 6 Intratelencephalic neuron</rdfs:label>
+        <skos:definition>is a Layer 6 Intratelencephalic neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000112 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000112">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000112</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Layer 6b neuron</preferred_name>
+        <prefixIRI>pCL:00000112</prefixIRI>
+        <tdc_id>Bakken59</tdc_id>
+        <rdfs:label>Layer 6b neuron</rdfs:label>
+        <skos:definition>is a Layer 6b neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000113 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000113">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000113</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>LAMP5 expressing GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000113</prefixIRI>
+        <rdfs:label>LAMP5-expressing GABAergic interneuron</rdfs:label>
+        <skos:definition>is a LAMP5 expressing GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000114">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000079"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000114</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>PVALB expressing GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000114</prefixIRI>
+        <rdfs:label>PVALB-expressing GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB expressing GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000115 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000115">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000115</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>SNCG-expressing primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000115</prefixIRI>
+        <rdfs:label>SNCG-expressing primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SNCG-expressing primary motor cortex GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000116 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000116">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000079"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000116</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>SST CHODL-expressing GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000116</prefixIRI>
+        <rdfs:label>SST CHODL-expressing GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST CHODL-expressing GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000117">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000079"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000117</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>SST-expressing GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000117</prefixIRI>
+        <rdfs:label>SST-expressing GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000118">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000118</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>VIP-expressing GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000118</prefixIRI>
+        <tdc_id>Bakken16</tdc_id>
+        <rdfs:label>VIP-expressing GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing GABAergic interneuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000119 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000119">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>L6 CT Kit_2</obo:PCL_0000100>
+        <id>pCL_00000273</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Nr4a2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000273</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken173</tdc_id>
+        <rdfs:label>Nr4a2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Nr4a2-expressing mouse primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses Gm26883, and Nr4a2, and Rxfp1, and Tshz2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000120 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000120">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1 LAMP5 BMP2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000120</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL5A2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000120</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken69</tdc_id>
+        <rdfs:label>COL5A2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a COL5A2-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses COL5A2, and FREM1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1 LAMP5 NMBR</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000121</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>is a COL5A2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000121</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken70</tdc_id>
+        <rdfs:label>PCDH18-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PCDH18-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses PCDH18, and RELN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000122 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000122">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1 LAMP5 PVRL2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000122</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HS3ST5-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000122</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken71</tdc_id>
+        <rdfs:label>HS3ST5-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HS3ST5-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses CBLN4, and HS3ST5, and RELN, and TRPC3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000123 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000123">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1 LAMP5 RAB11FIP1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000123</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTS20-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000123</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken72</tdc_id>
+        <rdfs:label>ADAMTS20-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADAMTS20-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses ADAMTS20, and FREM1, and MYH11 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000124 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000124">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1 PAX6 MIR101-1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000124</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>RELN-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000124</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken74</tdc_id>
+        <rdfs:label>RELN-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a RELN-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses RELN, and TGFBR2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000125 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000125">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1-6 LAMP5 AARD</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000125</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FBXL7-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000125</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken97</tdc_id>
+        <rdfs:label>FBXL7-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses FBXL7, and FREM1, and KIT, and PRELID2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000126 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000126">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1-6 LAMP5 CA1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000126</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HS3ST4-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000126</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken98</tdc_id>
+        <rdfs:label>HS3ST4-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HS3ST4-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses HS3ST4, and NOS1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000127 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000127">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1-6 LAMP5 NES</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000127</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EPHA3-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000127</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken99</tdc_id>
+        <rdfs:label>EPHA3-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EPHA3-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses EPHA3, and EYA4, and KIT, and NTNG1, and ROR2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000128 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000128">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L3-6 PAX6 LINC01497</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000128</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PALMD-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000128</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken119</tdc_id>
+        <rdfs:label>PALMD-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PALMD-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses PALMD, and RELN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000129 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000129">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L5-6 LAMP5 CRABP1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000129</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PDGFD-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000129</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken124</tdc_id>
+        <rdfs:label>PDGFD-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PDGFD-expressing human primary motor cortex LAMP5 GABAergic interneuron that selectively expresses LOC105379168, and PDGFD mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000130 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000130">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L1-2 PVALB CDK20</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000130</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTS12-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000130</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken79</tdc_id>
+        <rdfs:label>ADAMTS12-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADAMTS12-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses ADAMTS12, and SYT10, and TMEM132C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000131 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000131">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L1-2 SST CLIC6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000131</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ARHGAP42-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000131</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken81</tdc_id>
+        <rdfs:label>ARHGAP42-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ARHGAP42-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses ARHGAP42, and NEDD4, and TAC1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000132 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000132">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L1-6 PVALB COL15A1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000132</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL15A1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000132</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken100</tdc_id>
+        <rdfs:label>COL15A1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a COL15A1-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses COL15A1, and NPNT mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000133 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000133">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L2 PVALB FRZB</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000133</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLC9A9-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000133</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken104</tdc_id>
+        <rdfs:label>SLC9A9-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SLC9A9-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses CBLN4, and RGS5, and SLC9A9 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000134 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000134">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L2-5 PVALB HHIPL1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000134</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTS17-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000134</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken107</tdc_id>
+        <rdfs:label>ADAMTS17-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADAMTS17-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses ADAMTS17, and ADAMTS20, and MDFIC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000135 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000135">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L2-5 PVALB RPH3AL</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000135</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>WIF1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000135</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken108</tdc_id>
+        <rdfs:label>WIF1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a WIF1-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses ARHGAP42, and MYO5B, and POSTN, and WIF1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000136 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000136">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L3 PVALB SAMD13</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000136</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SULF1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000136</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken111</tdc_id>
+        <rdfs:label>SULF1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SULF1-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses LOC101928964, and SULF1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000137 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000137">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L3-5 PVALB ISG20</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000137</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SV2C-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000137</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken112</tdc_id>
+        <rdfs:label>SV2C-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SV2C-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses LOC101926942, and LOC105377862, and SV2C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000138 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000138">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5 PVALB LRIG3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000138</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SV2C-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000138</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken122</tdc_id>
+        <rdfs:label>CDH6-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CDH6-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses CDH6, and GPC5, and PLCE1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000139 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000139">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB FAM150B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000139</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FAM150B-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000139</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken125</tdc_id>
+        <rdfs:label>FAM150B-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FAM150B-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses FAM150B, and MYBPC1, and TNC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000140 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000140">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB GAPDHP60</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000140</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MYBPC1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000140</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken126</tdc_id>
+        <rdfs:label>MYBPC1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a MYBPC1-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses GPC5, and MYBPC1, and SEMA3C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000141 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000141">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB KCNIP2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000141</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GPC5-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000141</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken127</tdc_id>
+        <rdfs:label>GPC5-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GPC5-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses GPC5, and NPFFR2, and VAV3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000142">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB MEPE</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000142</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MEPE-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000142</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken128</tdc_id>
+        <rdfs:label>MEPE-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a MEPE-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses MEPE, and MYBPC1, and SVIL mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000143 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000143">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB ZFPM2-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000143</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PCDH15-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000143</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken130</tdc_id>
+        <rdfs:label>PCDH15-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PCDH15-expressing human primary motor cortex PVALB GABAergic interneuron that selectively expresses PCDH15, and SEMA6D, and ZFPM2_AS1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000144 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000144">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1 PAX6 CHRFAM7A</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000144</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CHRNA7-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000144</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken73</tdc_id>
+        <rdfs:label>CHRNA7-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CHRNA7-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses CHRNA7, and CNR1, and LINC01539 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000145 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000145">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1 PVALB SST ASIC4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000145</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAM33-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000145</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken75</tdc_id>
+        <rdfs:label>ADAM33-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADAM33-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses ADAM33, and NCKAP5, and PRELID2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000146 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000146">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1 SST DEFB108B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000146</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SYT10-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000146</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken76</tdc_id>
+        <rdfs:label>SYT10-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SYT10-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses NDST4, and SYT10 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000147 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000147">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1 SST P4HA3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000147</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ST8SIA6-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000147</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken77</tdc_id>
+        <rdfs:label>ST8SIA6-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ST8SIA6-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses ARHGAP42, and FOXO1, and ST8SIA6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000148 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000148">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1-2 VIP HTR3A</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000148</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HTR3A-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000148</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken84</tdc_id>
+        <rdfs:label>HTR3A-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HTR3A-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses HTR3A, and LOC105373642 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000149 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000149">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1-2 VIP WNT4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000149</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SYT9-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000149</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken87</tdc_id>
+        <rdfs:label>SYT9-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SYT9-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses LOC105379064, and SYT9 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000150 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000150">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L1-6 VIP SLC7A6OS</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000150</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CNR1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000150</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken102</tdc_id>
+        <rdfs:label>CNR1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CNR1-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses CNR1, and PBX3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000151 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000151">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh L2 PAX6 FREM2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000151</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CILP2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000151</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken103</tdc_id>
+        <rdfs:label>CILP2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CILP2-expressing human primary motor cortex SNCG GABAergic interneuron that selectively expresses CILP2, and IGFBP7 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000152 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000152">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L1-2 SST CCNJL</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000152</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CALB1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000152</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken80</tdc_id>
+        <rdfs:label>CALB1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CALB1-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses CALB1, and SPHKAP, and TMEM132C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000153 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000153">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L1-2 SST PRRT4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000153</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC101927843-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000153</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken82</tdc_id>
+        <rdfs:label>LOC101927843-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a LOC101927843-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses LOC101927843, and LOC101929028 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000154 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000154">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L1-3 SST FAM20A</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000154</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PCSK5-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000154</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken88</tdc_id>
+        <rdfs:label>PCSK5-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PCSK5-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses PCSK5, and TAC1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000155 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000155">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L2-3 SST NMU</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000155</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HPSE2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000155</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken106</tdc_id>
+        <rdfs:label>HPSE2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HPSE2-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses HPSE2, and NOS1, and PIEZO2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000156 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000156">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L3-5 SST CDH3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000156</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FREM1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000156</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken113</tdc_id>
+        <rdfs:label>FREM1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FREM1-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses FREM1, and NPNT, and QRFPR mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000157 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000157">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L3-5 SST GGTLC3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000157</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EYS-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000157</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken114</tdc_id>
+        <rdfs:label>EYS-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EYS-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses EYS, and RELN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000158 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000158">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L3-5 SST OR5AH1P</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000158</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTS5-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000158</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken115</tdc_id>
+        <rdfs:label>ADAMTS5-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADAMTS5-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses ADAMTS5, and FBXL7, and SST mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000159 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000159">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5 SST RPL35AP11</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000159</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EDNRA-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000159</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken123</tdc_id>
+        <rdfs:label>EDNRA-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EDNRA-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses EDNRA, and FREM1, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000160 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000160">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB SST CRHR2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000160</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HPGD-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000160</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken129</tdc_id>
+        <rdfs:label>HPGD-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HPGD-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses HPGD, and RGS5, and SPON1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000161 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST BEAN1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000161</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTSL1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000161</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken131</tdc_id>
+        <rdfs:label>ADAMTSL1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADAMTSL1-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses ADAMTSL1, and SEMA5A, and THSD7B, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000162 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000162">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST C4orf26</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000162</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SPON1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000162</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken132</tdc_id>
+        <rdfs:label>SPON1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SPON1-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses ADAMTS20, and PENK, and SPON1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000163 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000163">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST DNAJC14</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000163</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HGF-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000163</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken133</tdc_id>
+        <rdfs:label>HGF-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HGF-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses HGF, and ITGA1, and STON2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000164 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000164">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST FBN2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000164</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HCRTR2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000164</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken134</tdc_id>
+        <rdfs:label>HCRTR2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HCRTR2-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses HCRTR2, and KLHL1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000165 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000165">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST ISX</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000165</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL19A1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000165</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken135</tdc_id>
+        <rdfs:label>COL19A1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a COL19A1-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses COL19A1, and TRPM3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000166 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000166">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST KLHL1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000166</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KLHL14-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000166</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken136</tdc_id>
+        <rdfs:label>KLHL14-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KLHL14-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses KLHL14, and NDST4, and SLC17A8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000167 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000167">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST PAWR</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000167</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EPB41L4A-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000167</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken137</tdc_id>
+        <rdfs:label>EPB41L4A-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EPB41L4A-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses EPB41L4A, and NDST4, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000168 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000168">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST PIK3CD</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000168</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NDST4-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000168</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken138</tdc_id>
+        <rdfs:label>NDST4-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a NDST4-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses EPB41L4A, and NDST4, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000169 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000169">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L6 SST TH</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000169</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TH-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000169</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken140</tdc_id>
+        <rdfs:label>TH-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a TH-expressing human primary motor cortex SST GABAergic interneuron that selectively expresses LOC100128108, and TH mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000170 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000170">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000116"/>
+        <obo:PCL_0000100>Inh L1-6 SST NPY</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000170</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NPY-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000170</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken101</tdc_id>
+        <rdfs:label>NPY-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a NPY-expressing human primary motor cortex SST CHODL GABAergic interneuron that selectively expresses NPY mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000171 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000171">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1 VIP KLHDC8B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000171</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ITGBL1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000171</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken78</tdc_id>
+        <rdfs:label>ITGBL1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ITGBL1-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses ITGBL1, and SLITRK4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000172 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000172">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 VIP EXPH5</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000172</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SCTR-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000172</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken83</tdc_id>
+        <rdfs:label>SCTR-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SCTR-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses SCTR, and ST18 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000173">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 VIP PTGER3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000173</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PARD3B-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000173</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken85</tdc_id>
+        <rdfs:label>PARD3B-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PARD3B-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses KCNH8, and PARD3B, and SYT10 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000174 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000174">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 VIP SCML4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000174</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ABI3BP-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000174</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken86</tdc_id>
+        <rdfs:label>ABI3BP-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ABI3BP-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses ABI3BP, and KCNH8, and LOC100506497 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000175 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000175">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP CBLN1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000175</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HTR2C-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000175</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken89</tdc_id>
+        <rdfs:label>HTR2C-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a HTR2C-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses HTR2C, and LOC284825, and TAC3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000176 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000176">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP CHRNA2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000176</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EYA4-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000176</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken90</tdc_id>
+        <rdfs:label>EYA4-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EYA4-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses EYA4, and LOC105373642, and PPP1R1C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000177 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000177">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP FNDC1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000177</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KCNH8-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000177</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken91</tdc_id>
+        <rdfs:label>KCNH8-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KCNH8-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses KCNH8, and LOC101927286, and LOC101928842 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000178 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000178">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP HSPB6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000178</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CCNG2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000178</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken92</tdc_id>
+        <rdfs:label>CCNG2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CCNG2-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses CCNG2, and IGFBP5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000179 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000179">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-5 VIP CD27-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000179</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ANKFN1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000179</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken93</tdc_id>
+        <rdfs:label>ANKFN1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ANKFN1-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses ANKFN1, and EGFEM1P, and IQGAP2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000180 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000180">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-5 VIP LINC01013</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000180</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>DACH2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000180</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken94</tdc_id>
+        <rdfs:label>DACH2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a DACH2-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses DACH2, and SRGAP1, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000181 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000181">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-5 VIP PHLDB3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000181</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EGF-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000181</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken95</tdc_id>
+        <rdfs:label>EGF-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EGF-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses EGF, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000182 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000182">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-5 VIP SMOC1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000182</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ANGPT1-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000182</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken96</tdc_id>
+        <rdfs:label>ANGPT1-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ANGPT1-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses ANGPT1, and SMOC1, and VIP mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000183 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000183">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2 VIP SLC6A16</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000183</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KCNT2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000183</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken105</tdc_id>
+        <rdfs:label>KCNT2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KCNT2-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses KCNT2, and LOC105370456 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000184 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000184">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-5 VIP BSPRY</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000184</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PDE3A-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000184</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken109</tdc_id>
+        <rdfs:label>PDE3A-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PDE3A-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses LOC101927078, and PDE3A, and ST18 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000185 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000185">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-5 VIP SOX11</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000185</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>THSD7B-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000185</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken110</tdc_id>
+        <rdfs:label>THSD7B-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a THSD7B-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses ADAMTSL1, and HTR2C, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000186 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000186">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L3-5 VIP HS3ST3A1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000186</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLC22A3-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000186</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken116</tdc_id>
+        <rdfs:label>SLC22A3-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SLC22A3-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses ABI3BP, and IQGAP2, and SLC22A3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000187 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000187">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L3-5 VIP IGDCC3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000187</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EREG-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000187</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken117</tdc_id>
+        <rdfs:label>EREG-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EREG-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses EREG, and NOX4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000188 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000188">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L3-5 VIP TAC3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000188</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TSHZ2-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000188</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken118</tdc_id>
+        <rdfs:label>TSHZ2-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a TSHZ2-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses COL19A1, and SOX2_OT, and TSHZ2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000189 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000189">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L3-6 VIP UG0898H09</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000189</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GALNT10-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000189</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken120</tdc_id>
+        <rdfs:label>GALNT10-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GALNT10-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses GALNT10, and LINC01411, and LOC105373454 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000190 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000190">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L3-6 VIP ZIM2-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000190</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CXCL14-expressing human primary motor cortex VIP GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000190</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken121</tdc_id>
+        <rdfs:label>CXCL14-expressing human primary motor cortex VIP GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CXCL14-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses CXCL14, and PENK mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000191 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000191">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L5-6 VIP COL4A3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000191</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KCTD12-expressing human primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000191</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken139</tdc_id>
+        <rdfs:label>KCTD12-expressing human primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KCTD12-expressing human primary motor cortex VIP GABAergic interneuron that selectively expresses CXCL14, and PENK mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000192 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000192">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2 LAMP5 KCNG3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_00000192</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SAMD3-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000192</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <tdc_id>Bakken25</tdc_id>
+        <rdfs:label>SAMD3-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SAMD3-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses FAM163A, and LOC101927668, and SAMD3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000193 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000193">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2 LINC00507 ATP7B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_00000193</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ACVR1C-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000193</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken26</tdc_id>
+        <rdfs:label>ACVR1C-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ACVR1C-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses ACVR1C, and LOC105377209 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000194 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000194">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2 LINC00507 GLRA3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_00000194</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LINC01378-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000194</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken27</tdc_id>
+        <rdfs:label>LINC01378-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LINC01378-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses LINC01378, and LOC101928278, and SERPINE2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000195 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000195">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2-3 LINC00507 DSG3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000195</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>BMPR1B-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000195</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken28</tdc_id>
+        <rdfs:label>BMPR1B-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a BMPR1B-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses BDNF, and BMPR1B, and LOC105379003 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000196 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000196">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2-3 RORB CCDC68</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000196</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COBLL1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000196</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken29</tdc_id>
+        <rdfs:label>COBLL1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COBLL1-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses COBLL1, and COL5A2, and PRSS12 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000197 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000197">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2-3 RORB PTPN3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000197</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL5A2-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000197</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken30</tdc_id>
+        <rdfs:label>COL5A2-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COL5A2-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses COL5A2, and LOC105370610, and LOC105378334, and RORB mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000198 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000198">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L2-3 RORB RTKN2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000198</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PLCH1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000198</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken31</tdc_id>
+        <rdfs:label>PLCH1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a PLCH1-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses LOC101927745, and LOC105376987, and PLCH1, and RMST mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000199 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000199">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc L3 LAMP5 CARM1P1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000199</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EPB41L4A-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000199</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken32</tdc_id>
+        <rdfs:label>EPB41L4A-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EPB41L4A-expressing human primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses EPB41L4A, and SV2C, and SYT2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000200 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000200">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 FEZF2 ASGR2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000200</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>OR51E2-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000200</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken35</tdc_id>
+        <rdfs:label>OR51E2-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC105376457-expressing human primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses LOC105376457, and OR51E2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000201 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 FEZF2 LINC01107</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000201</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>BTNL9-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000201</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken36</tdc_id>
+        <rdfs:label>BTNL9-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a BTNL9-expressing human primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses BTNL9, and EDNRB mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000202 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000202">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L5 FEZF2 CSN1S1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000202</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>VAT1L-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000202</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken42</tdc_id>
+        <rdfs:label>VAT1L-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a VAT1L-expressing human primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses LOC105373592, and OPN4, and VAT1L mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000203 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000203">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3 RORB OTOGL</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000203</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL22A1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000203</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken33</tdc_id>
+        <rdfs:label>COL22A1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COL22A1-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses COL22A1, and RMST mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000204 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000204">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3 THEMIS ENPEP</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_00000204</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FAP-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000204</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken34</tdc_id>
+        <rdfs:label>FAP-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a FAP-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses FAP, and LAMA2, and LOC101928964, and LOC105376081 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000205 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000205">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 RORB LAMA4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000205</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KCNH8-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000205</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken37</tdc_id>
+        <rdfs:label>KCNH8-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a KCNH8-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses KCNH8, and LOC100128497, and LOC101927281, and LOC105376081, and TRPC3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000206 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000206">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 RORB LINC01202</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000206</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC101927874-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000206</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken38</tdc_id>
+        <rdfs:label>LOC101927874-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC101927874-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses LOC101927874, and LOC105374971, and LOC105376081, and LOC105377703 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000207 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000207">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 RORB LNX2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000207</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TRABD2A-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000207</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken39</tdc_id>
+        <rdfs:label>TRABD2A-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TRABD2A-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses LOC105374971, and LOC105377703, and TRABD2A mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000208 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000208">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 RORB RPRM</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000208</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>RPRM-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000208</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken40</tdc_id>
+        <rdfs:label>RPRM-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a RPRM-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses LOC105374971, and LOC105374973, and RPRM mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000209 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000209">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L3-5 RORB TNNT2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000209</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FSHR-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000209</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken41</tdc_id>
+        <rdfs:label>FSHR-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a FSHR-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses FSHR, and LOC100507562, and LOC105376081 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000210 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000210">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L5 RORB MED8</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000210</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NPFFR2-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000210</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken46</tdc_id>
+        <rdfs:label>NPFFR2-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a NPFFR2-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses COL22A1, and LOC401134, and NPFFR2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000211 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L5 THEMIS FGF10</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000211</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>BDNF-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000211</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken47</tdc_id>
+        <rdfs:label>BDNF-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a BDNF-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses BDNF, and CRH, and NPFFR2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000212 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000212">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L5 THEMIS SLC22A18</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000212</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLC7A11-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000212</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken50</tdc_id>
+        <rdfs:label>SLC7A11-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC7A11-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses BTNL9, and CCBE1, and LOC401134, and SLC7A11 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000213 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000213">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L5 THEMIS VILL</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000213</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>DACH1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000213</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken51</tdc_id>
+        <rdfs:label>DACH1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a DACH1-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses DACH1, and LOC101927389, and TNC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000214 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000214">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc L5-6 THEMIS TNFAIP6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000214</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LTBP1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000214</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken60</tdc_id>
+        <rdfs:label>LTBP1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LTBP1-expressing human primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses LOC105373893, and LOC105378031, and LTBP1, and TSHZ2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000215 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000215">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>Exc L5 FEZF2 NREP-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000215</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTS12-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000215</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken43</tdc_id>
+        <rdfs:label>ADAMTS12-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ADAMTS12-expressing human primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses ADAMTS12, and CD36, and LOC105370315 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000216 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000216">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>Exc L5 FEZF2 PKD2L1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000216</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NPSR1_AS1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000216</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken44</tdc_id>
+        <rdfs:label>NPSR1_AS1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a NPSR1_AS1-expressing human primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses NPSR1_AS1, and VGLL3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000217 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000217">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>Exc L5 FEZF2 RNF144A-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000217</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CD36-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000217</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken45</tdc_id>
+        <rdfs:label>CD36-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CD36-expressing human primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses CD36, and LOC105369818, and LOC105370019 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000218 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000218">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 IFNG-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000218</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC105369818-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000218</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken55</tdc_id>
+        <rdfs:label>LOC105369818-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC105369818-expressing human primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses LOC105369818, and NPSR1_AS1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000219 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000219">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 LPO</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000219</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC105369818-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000219</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken56</tdc_id>
+        <rdfs:label>LOC101928114-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC101928114-expressing human primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses LOC101928114, and LOC105376372 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000220 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000220">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc L5 THEMIS LINC01116</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000220</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC105369890-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000220</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken48</tdc_id>
+        <rdfs:label>LOC105369890-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC105369890-expressing human primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses LOC105369890, and LOC105371663 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000221 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000221">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc L5 THEMIS RGPD6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_00000221</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>DDR2-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000221</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken49</tdc_id>
+        <rdfs:label>DDR2-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a DDR2-expressing human primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses DDR2, and LOC105371663, and THEMIS mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000222 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000222">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 C9orf135-AS1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000222</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EGFEM1P-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000222</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken52</tdc_id>
+        <rdfs:label>EGFEM1P-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EGFEM1P-expressing human primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses EGFEM1P, and FOXP2, and SEMA5A mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000223 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000223">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 FILIP1L</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000223</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SEC16B-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000223</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken54</tdc_id>
+        <rdfs:label>SEC16B-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SEC16B-expressing human primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses LOC100128497, and MCTP2, and SEC16B, and SULF1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000224 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000224">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 OR1L8</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000224</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LGR6-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000224</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken57</tdc_id>
+        <rdfs:label>LGR6-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LGR6-expressing human primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses LGR6, and LOC101927439, and LOC105374392, and LOC105377183 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000225 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000225">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 SH2D1B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000225</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADAMTSL1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000225</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken58</tdc_id>
+        <rdfs:label>ADAMTSL1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ADAMTSL1-expressing human primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses ADAMTSL1, and MEIS2, and NLGN4Y, and PAPSS2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000226 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000226">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>Exc L6 THEMIS LINC00343</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000226</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ANKRD30B-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000226</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken66</tdc_id>
+        <rdfs:label>ANKRD30B-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ANKRD30B-expressing human primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses ANKRD30B, and LINC00299, and LINC00343 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000227 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000227">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>Exc L6 THEMIS SLN</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000227</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FAM163A-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000227</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken67</tdc_id>
+        <rdfs:label>FAM163A-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a FAM163A-expressing human primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses FAM163A, and LOC105371832, and LOC105374524 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000228 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000228">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>Exc L6 THEMIS SNTG2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000228</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC101927389-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000228</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken68</tdc_id>
+        <rdfs:label>LOC101927389-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC101927389-expressing human primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses LOC101927389, and LOC105371310 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000229 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000229">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000110"/>
+        <obo:PCL_0000100>Exc L5-6 THEMIS SMYD1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000229</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ATP10A-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000229</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken59</tdc_id>
+        <rdfs:label>ATP10A-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ATP10A-expressing human primary motor cortical layer 6 intratelencephalic Car3 glutamatergic neuron that selectively expresses ATP10A, and TRPC5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000230 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000230">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 CFTR</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000230</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SEMA3D-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000230</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken53</tdc_id>
+        <rdfs:label>SEMA3D-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SEMA3D-expressing human primary motor cortical layer 6b glutamatergic neuron that selectively expresses LOC105374392, and NR4A2, and SEMA3D mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000231 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000231">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 FFAR4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000231</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FER1L6_AS2-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000231</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken61</tdc_id>
+        <rdfs:label>FER1L6_AS2-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a FER1L6_AS2-expressing human primary motor cortical layer 6b glutamatergic neuron that selectively expresses FER1L6_AS2, and LOC105378486 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000232 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 KLK7</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000232</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MDFIC-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000232</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken62</tdc_id>
+        <rdfs:label>MDFIC-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a MDFIC-expressing human primary motor cortical layer 6b glutamatergic neuron that selectively expresses LOC101927439, and MDFIC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000233 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000233">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 PDYN</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000233</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GBP2-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000233</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken63</tdc_id>
+        <rdfs:label>GBP2-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a MDFIC-expressing human primary motor cortical layer 6b glutamatergic neuron that selectively expresses LOC101927439, and MDFIC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000234 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000234">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 POGK</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000234</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADD3_AS1-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000234</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken64</tdc_id>
+        <rdfs:label>ADD3_AS1-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ADD3_AS1-expressing human primary motor cortical layer 6b glutamatergic neuron that selectively expresses ADD3_AS1, and LOC100132891, and PCOLCE2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000235 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000235">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 PROKR2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_00000235</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLITRK6-expressing human primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000235</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken65</tdc_id>
+        <rdfs:label>SLITRK6-expressing human primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLITRK6-expressing human primary motor cortical layer 6b glutamatergic neuron that selectively expresses LOC105371310, and SLITRK6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000236 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000236">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo L2-6 OPALIN FTH1P3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000236</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>STK32A-expressing human primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000236</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken142</tdc_id>
+        <rdfs:label>STK32A-expressing human primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a STK32A-expressing human primary motor cortex oligodendrocyte that selectively expresses STK32A, and VCAN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000237 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000237">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo L3-6 OPALIN ENPP6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000237</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ST18-expressing human primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000237</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken144</tdc_id>
+        <rdfs:label>ST18-expressing human primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a ENPP2-expressing human primary motor cortex oligodendrocyte that selectively expresses ENPP2, and LINC01378, and MBP, and ST18 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000238 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000238">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo L2-6 OPALIN MAP6D1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000238</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ENPP2-expressing human primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000238</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken143</tdc_id>
+        <rdfs:label>ENPP2-expressing human primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a ENPP2-expressing human primary motor cortex oligodendrocyte that selectively expresses ENPP2, and LOC101927459 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000239 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000239">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro L1-6 FGFR3 PLCG1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000239</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL5A3-expressing human primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000239</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken23</tdc_id>
+        <rdfs:label>COL5A3-expressing human primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a COL5A3-expressing human primary motor cortex astrocyte that selectively expresses COL5A3 and LOC105376917 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000240 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000240">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129"/>
+        <obo:PCL_0000100>Micro L1-6 TYROBP CD74</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000240</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>APBB1IP-expressing human primary motor cortex microglial cell</preferred_name>
+        <prefixIRI>pCL:0000240</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken141</tdc_id>
+        <rdfs:label>APBB1IP-expressing human primary motor cortex microglial cell</rdfs:label>
+        <skos:definition>is a APBB1IP-expressing human primary motor cortex microglial cell that selectively expresses APBB1IP, and P2RY12 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000241 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000241">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002453"/>
+        <obo:PCL_0000100>OPC L1-6 PDGFRA COL20A1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000241</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FAM222A-expressing human primary motor cortex oligodendrocyte precursor cell</preferred_name>
+        <prefixIRI>pCL:0000241</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken147</tdc_id>
+        <rdfs:label>FAM222A-expressing human primary motor cortex oligodendrocyte precursor cell</rdfs:label>
+        <skos:definition>is a FAM222A-expressing human primary motor cortex oligodendrocyte precursor cell that selectively expresses FAM222A, and KIF25, and TGFA mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000242 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000242">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>L6 CT Pou3f2</obo:PCL_0000100>
+        <id>pCL_00000274</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cdh18-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000274</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken174</tdc_id>
+        <rdfs:label>Cdh18-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Cdh18-expressing mouse primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses Cdh18, and Gm10635, and Satb2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000243 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000243">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro L1-6 FGFR3 AQP1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000243</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TNC-expressing human primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000243</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken22</tdc_id>
+        <rdfs:label>TNC-expressing human primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a TNC-expressing human primary motor cortex astrocyte that selectively expresses TNC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000244 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000244">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro L1 FGFR3 SERPINI2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000244</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CFAP47-expressing human primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000244</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken21</tdc_id>
+        <rdfs:label>CFAP47-expressing human primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a CFAP47-expressing human primary motor cortex astrocyte that selectively expresses CFAP47|HGNC:26708, and WDR49|HGNC:26587 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000245 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000245">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo L5-6 OPALIN LDLRAP1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000245</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>RNF219_AS1-expressing human primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000245</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken146</tdc_id>
+        <rdfs:label>RNF219_AS1-expressing human primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a RNF219_AS1-expressing human primary motor cortex oligodendrocyte that selectively expresses LOC105376917, and OPALIN, and RNF219_AS1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000246 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000246">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602"/>
+        <obo:PCL_0000100>Endo L2-5 NOSTRIN SRGN</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000246</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CLDN5-expressing human primary motor cortex endothelial cell</preferred_name>
+        <prefixIRI>pCL:0000246</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>human</species_source>
+        <tdc_id>Bakken24</tdc_id>
+        <rdfs:label>CLDN5-expressing human primary motor cortex endothelial cell</rdfs:label>
+        <skos:definition>is a CLDN5-expressing human primary motor cortex endothelial cell that selectively expresses CLDN5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000247 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000247">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC L1-5 PDGFRA COLEC12</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000247</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL1A2-expressing human primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000247</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Bakken148</tdc_id>
+        <rdfs:label>COL1A2-expressing human primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a COL1A2-expressing human primary motor cortex vascular leptomeningeal cell that selectively expresses COL1A2, and COLEC12 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000248 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000248">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro Aqp4_Gfap</obo:PCL_0000100>
+        <id>pCL_0000248</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Myoc-expressing mouse primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000248</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>Mouse</species_source>
+        <tdc_id>Bakken148</tdc_id>
+        <rdfs:label>Myoc-expressing mouse primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a Myoc-expressing mouse primary motor cortex astrocyte that selectively expresses Myoc mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000249 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000249">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro Aqp4_Slc7a10</obo:PCL_0000100>
+        <id>pCL_0000249</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Phkg1-expressing mouse primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000249</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>Mouse</species_source>
+        <tdc_id>Bakken149</tdc_id>
+        <rdfs:label>Phkg1-expressing mouse primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a Phkg1-expressing mouse primary motor cortex astrocyte that selectively expresses Phkg1, and Slco1c1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000250 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000250">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro_Top2a</obo:PCL_0000100>
+        <id>pCL_0000250</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Clspn-expressing mouse primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000250</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>Mouse</species_source>
+        <tdc_id>Bakken150</tdc_id>
+        <rdfs:label>Clspn-expressing mouse primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a Clspn-expressing mouse primary motor cortex astrocyte that selectively expresses Clspn, and Lockd mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000251 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000251">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602"/>
+        <obo:PCL_0000100>Endo</obo:PCL_0000100>
+        <id>pCL_0000251</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Adgrl4-expressing mouse primary motor cortex endothelial cell</preferred_name>
+        <prefixIRI>pCL:0000251</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken151</tdc_id>
+        <rdfs:label>Adgrl4-expressing mouse primary motor cortex endothelial cell</rdfs:label>
+        <skos:definition>is a Adgrl4-expressing mouse primary motor cortex endothelial cell that selectively expresses Adgrl4, and Slco1a4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000252 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000252">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>L2/3 IT_1</obo:PCL_0000100>
+        <id>pCL_00000252</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Adamts2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000252</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken152</tdc_id>
+        <rdfs:label>Adamts2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Adamts2-expressing mouse primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses 6530403H02Rik, and Adamts2, and Met mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000253 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000253">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>L2/3 IT_2</obo:PCL_0000100>
+        <id>pCL_00000253</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Ccdc3-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000253</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken153</tdc_id>
+        <rdfs:label>Ccdc3-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Ccdc3-expressing mouse primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses Ccdc3, and Cux1, and Meis2, and Otof mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000254 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000254">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>L2/3 IT_3</obo:PCL_0000100>
+        <id>pCL_00000254</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cux2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000254</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken154</tdc_id>
+        <rdfs:label>Cux2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Cux2-expressing mouse primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses Cux2, and Slit3, and Stard8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000256 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000256">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>L5 PT_2</obo:PCL_0000100>
+        <id>pCL_00000256</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Erg-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000256</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken156</tdc_id>
+        <rdfs:label>Erg-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Erg-expressing mouse primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses Erg, and Gpc5, and Trpc7 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000257 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000257">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>L5 PT_3</obo:PCL_0000100>
+        <id>pCL_00000257</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Trpc7-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000257</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken157</tdc_id>
+        <rdfs:label>Trpc7-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Trpc7-expressing mouse primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses 6430573F11Rik, and Gpc5, and Reln, and Trpc7 mRNA</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000258 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000258">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>L5 PT_4</obo:PCL_0000100>
+        <id>pCL_00000258</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Npsr1-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000258</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken158</tdc_id>
+        <rdfs:label>Npsr1-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Npsr1-expressing mouse primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses Gm2164, and Npsr1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000259 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000259">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>L5 IT_3</obo:PCL_0000100>
+        <id>pCL_00000259</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Enpp2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000259</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken159</tdc_id>
+        <rdfs:label>Enpp2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Enpp2-expressing mouse primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses Cadps2, and Enpp2, and Pld5, and Ptprk, and Rxfp1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000260 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>L5 IT_4</obo:PCL_0000100>
+        <id>pCL_00000260</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Chrm2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000260</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken160</tdc_id>
+        <rdfs:label>Chrm2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Chrm2-expressing mouse primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses Chrm2, and Cwh43, and Pld5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000261 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000261">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>L4/5 IT_1</obo:PCL_0000100>
+        <id>pCL_00000261</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cadps2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000261</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken161</tdc_id>
+        <rdfs:label>Cadps2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Cadps2-expressing mouse primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses Cadps2, and Prr16, and Rorb mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000262 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000262">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>L4/5 IT_2</obo:PCL_0000100>
+        <id>pCL_00000262</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Col26a1-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000262</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken162</tdc_id>
+        <rdfs:label>Col26a1-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Col26a1-expressing mouse primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses Col26a1, and Cpne4, and Il1rapl2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000263 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000263">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>L5 IT_1</obo:PCL_0000100>
+        <id>pCL_00000263</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Deptor-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000263</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken163</tdc_id>
+        <rdfs:label>Deptor-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Deptor-expressing mouse primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses Deptor, and Il1rapl2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000264 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000264">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>L5 IT_2</obo:PCL_0000100>
+        <id>pCL_00000264</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Adamts18-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000264</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken164</tdc_id>
+        <rdfs:label>Adamts18-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Adamts18-expressing mouse primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses AC129186_1, and Adamts18, and Deptor, and Man1a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000266 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000266">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>L5/6 NP_1</obo:PCL_0000100>
+        <id>pCL_00000266</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cyp7b1-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000265</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken166</tdc_id>
+        <rdfs:label>Cyp7b1-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Cyp7b1-expressing mouse primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses Cyp7b1, and Dkk2, and Vwc2l mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000267 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000267">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>L5/6 NP_2</obo:PCL_0000100>
+        <id>pCL_00000267</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Abi3bp-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000267</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken167</tdc_id>
+        <rdfs:label>Abi3bp-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Abi3bp-expressing mouse primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses Abi3bp, and Slc17a8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000268 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000268">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>L5/6 NP_3</obo:PCL_0000100>
+        <id>pCL_00000268</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Lypd1-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000268</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken168</tdc_id>
+        <rdfs:label>Lypd1-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Lypd1-expressing mouse primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses Lypd1, and Tshz2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000269 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000269">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>L6 CT Cpa6</obo:PCL_0000100>
+        <id>pCL_00000269</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Zfpm2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000269</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken169</tdc_id>
+        <rdfs:label>Zfpm2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Zfpm2-expressing mouse primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses Foxp2, and Hs3st4, and Zfpm2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000270 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000270">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>L6 CT Gpr139</obo:PCL_0000100>
+        <id>pCL_00000270</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Acaa1b-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000270</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken170</tdc_id>
+        <rdfs:label>Acaa1b-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Acaa1b-expressing mouse primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses Acaa1b, and Col23a1, and Gpr139 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000271 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000271">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>L6 CT Grp</obo:PCL_0000100>
+        <id>pCL_00000271</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pdzrn4-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000271</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken171</tdc_id>
+        <rdfs:label>Pdzrn4-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Pdzrn4-expressing mouse primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses Grp, and Meis2, and Pdzrn4, and Plcxd3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000272 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000272">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>L6 CT Kit_1</obo:PCL_0000100>
+        <id>pCL_00000272</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Ikzf2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000272</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken172</tdc_id>
+        <rdfs:label>Ikzf2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Ikzf2-expressing mouse primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses Gm10635, and Ikzf2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000274 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000274">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB ANKRD27</obo:PCL_0000100>
+        <id>pCL_00000381</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GRAMD1C-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000381</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken277</tdc_id>
+        <rdfs:label>GRAMD1C-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a GRAMD1C-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses GRAMD1C, and PLCH1, and POU6F2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000275 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000275">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000110"/>
+        <obo:PCL_0000100>L6 IT Car3</obo:PCL_0000100>
+        <id>pCL_00000275</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Tfap2d-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000277</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken175</tdc_id>
+        <rdfs:label>Tfap2d-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Tfap2d-expressing mouse primary motor cortex layer 6 intratelencephalic Car3 glutamatergic neuron that selectively expresses Nr4a2, and Tfap2d mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000276 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000276">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>L6 IT_1</obo:PCL_0000100>
+        <id>pCL_00000276</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Bmpr1b-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000276</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken176</tdc_id>
+        <rdfs:label>Bmpr1b-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Bmpr1b-expressing mouse primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses Bmpr1b, and Fst, and Ntng1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000277 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000277">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>L6 IT_2</obo:PCL_0000100>
+        <id>pCL_00000277</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>C1ql3-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000277</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken177</tdc_id>
+        <rdfs:label>C1ql3-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a C1ql3-expressing mouse primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses Bmpr1b, and C1ql3, and Ptpru mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000278 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000278">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>L6b Col6a1</obo:PCL_0000100>
+        <id>pCL_00000278</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Ctgf-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000278</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken178</tdc_id>
+        <rdfs:label>Ctgf-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Ctgf-expressing mouse primary motor cortical layer 6b glutamatergic neuron that selectively expresses Bmpr1b, and Ctgf, and Hs3st2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000279 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000279">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>L6b Kcnip1</obo:PCL_0000100>
+        <id>pCL_00000279</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Rxfp2-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000279</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken179</tdc_id>
+        <rdfs:label>Rxfp2-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Rxfp2-expressing mouse primary motor cortical layer 6b glutamatergic neuron that selectively expresses Gm42557, and Olfr112, and Rxfp2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000280 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000280">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>L6b Ror1</obo:PCL_0000100>
+        <id>pCL_00000280</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Fbxl7-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000280</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken180</tdc_id>
+        <rdfs:label>Fbxl7-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Fbxl7-expressing mouse primary motor cortical layer 6b glutamatergic neuron that selectively expresses Cplx3, and Ctgf, and Fbxl7 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000281 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000281">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>L6b Shisa6_1</obo:PCL_0000100>
+        <id>pCL_00000281</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Ly6g6e-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000281</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken181</tdc_id>
+        <rdfs:label>Ly6g6e-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Ly6g6e-expressing mouse primary motor cortical layer 6b glutamatergic neuron that selectively expresses Cplx3, and Ly6g6e, and Svil mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000282 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000282">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>L6b Shisa6_2</obo:PCL_0000100>
+        <id>pCL_00000282</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Moxd1-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000282</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken182</tdc_id>
+        <rdfs:label>Moxd1-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Moxd1-expressing mouse primary motor cortical layer 6b glutamatergic neuron that selectively expresses Moxd1, and Nr4a2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000283 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000283">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Egln3_1</obo:PCL_0000100>
+        <id>pCL:0000283</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Chrna7-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000283</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken183</tdc_id>
+        <rdfs:label>Chrna7-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Chrna7-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Chrna7, and Fam19a1, and Fbn2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000284 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000284">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Egln3_2</obo:PCL_0000100>
+        <id>pCL:0000284</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Crim1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000284</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken184</tdc_id>
+        <rdfs:label>Crim1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Crim1-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Crim1, and Zfp804b mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000285 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000285">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Egln3_3</obo:PCL_0000100>
+        <id>pCL:0000285</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cxcl14-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000285</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken185</tdc_id>
+        <rdfs:label>Cxcl14-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cxcl14-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Cxcl14, and Ntn1, and Reln mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000286 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000286">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Lhx6</obo:PCL_0000100>
+        <id>pCL:0000286</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Gm45680-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000286</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken186</tdc_id>
+        <rdfs:label>Gm45680-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Gm45680-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Gm45680, and Nos1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000287 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000287">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Pax6</obo:PCL_0000100>
+        <id>pCL:0000287</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pax6-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000287</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken187</tdc_id>
+        <rdfs:label>Pax6-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Pax6-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Pax6, and Pip5k1b mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000288 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000288">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Pdlim5_1</obo:PCL_0000100>
+        <id>pCL:0000288</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Dock5-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000288</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken188</tdc_id>
+        <rdfs:label>Dock5-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Dock5-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Dock5, and Ndnf, and Ndst4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000289 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000289">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Pdlim5_2</obo:PCL_0000100>
+        <id>pCL:0000289</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Ndnf-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000289</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken189</tdc_id>
+        <rdfs:label>Ndnf-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Ndnf-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Ndnf, and Pde11a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000290 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000290">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Lamp5 Slc35d3</obo:PCL_0000100>
+        <id>pCL:0000290</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Alk-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000290</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken190</tdc_id>
+        <rdfs:label>Alk-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Alk-expressing mouse primary motor cortex LAMP5 GABAergic interneuron that selectively expresses Alk, and Sema5a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000293 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000293">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129"/>
+        <obo:PCL_0000100>Micro</obo:PCL_0000100>
+        <id>pCL_0000293</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Hexb-expressing mouse primary motor cortex microglial cell</preferred_name>
+        <prefixIRI>pCL:0000293</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken193</tdc_id>
+        <rdfs:label>Hexb-expressing mouse primary motor cortex microglial cell</rdfs:label>
+        <skos:definition>is a Hexb-expressing mouse primary motor cortex microglial cell that selectively expresses Hexb mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000294 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000294">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002453"/>
+        <obo:PCL_0000100>OPC Pdgfra</obo:PCL_0000100>
+        <id>pCL_0000294</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pdgfra-expressing mouse primary motor cortex oligodendrocyte precursor cell</preferred_name>
+        <prefixIRI>pCL:0000294</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken194</tdc_id>
+        <rdfs:label>Pdgfra-expressing mouse primary motor cortex oligodendrocyte precursor cell</rdfs:label>
+        <skos:definition>is a Pdgfra-expressing mouse primary motor cortex oligodendrocyte precursor cell that selectively expresses Pdgfra, and Stk32a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000295 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000295">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Enpp6_1</obo:PCL_0000100>
+        <id>pCL_0000295</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Bcas1-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000295</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken195</tdc_id>
+        <rdfs:label>Bcas1-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Bcas1-expressing mouse primary motor cortex oligodendrocyte that selectively expresses Bcas1, and Tcf7l2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000296 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000296">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Enpp6_2</obo:PCL_0000100>
+        <id>pCL_0000296</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Bmp4-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000296</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken196</tdc_id>
+        <rdfs:label>Bmp4-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Bmp4-expressing mouse primary motor cortex oligodendrocyte that selectively expresses 9630013A20Rik, and Bmp4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000297 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000297">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Enpp6_3</obo:PCL_0000100>
+        <id>pCL_0000297</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Tmem163-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000297</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken197</tdc_id>
+        <rdfs:label>Tmem163-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Tmem163-expressing mouse primary motor cortex oligodendrocyte that selectively expresses Cnksr3, and Mpzl1, and Nckap5, and Tmem163 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000298 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000298">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Enpp6_4</obo:PCL_0000100>
+        <id>pCL_0000298</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cnksr3-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000298</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken198</tdc_id>
+        <rdfs:label>Cnksr3-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Cnksr3-expressing mouse primary motor cortex oligodendrocyte that selectively expresses 9630013A20Rik, and Cnksr3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000299 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000299">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Opalin_1</obo:PCL_0000100>
+        <id>pCL_0000299</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Anln-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000299</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken199</tdc_id>
+        <rdfs:label>Anln-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Anln-expressing mouse primary motor cortex oligodendrocyte that selectively expresses A330049N07Rik, and Anln, and Rftn1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000300 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000300">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Opalin_2</obo:PCL_0000100>
+        <id>pCL_0000300</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Il33-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000300</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken200</tdc_id>
+        <rdfs:label>Il33-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Il33-expressing mouse primary motor cortex oligodendrocyte that selectively expresses Il33, and Prr5l mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000301 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000301">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Opalin_3</obo:PCL_0000100>
+        <id>pCL_0000301</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cacna2d4-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000301</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken201</tdc_id>
+        <rdfs:label>Cacna2d4-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Cacna2d4-expressing mouse primary motor cortex oligodendrocyte that selectively expresses Cacna2d4, and Mobp, and Nckap5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000302 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000302">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo Opalin_4</obo:PCL_0000100>
+        <id>pCL_0000302</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Kank1-expressing mouse primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000302</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken202</tdc_id>
+        <rdfs:label>Kank1-expressing mouse primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a Kank1-expressing mouse primary motor cortex oligodendrocyte that selectively expresses Kank1, and Prom1, and Sytl2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000303 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000303">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000881"/>
+        <obo:PCL_0000100>PVM_1</obo:PCL_0000100>
+        <id>pCL_0000303</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Ms4a4a-expressing mouse primary motor cortex perivascular macrophage</preferred_name>
+        <prefixIRI>pCL:0000303</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken203</tdc_id>
+        <rdfs:label>Ms4a4a-expressing mouse primary motor cortex perivascular macrophage</rdfs:label>
+        <skos:definition>is a Ms4a4a-expressing mouse primary motor cortex perivascular macrophage that selectively expresses Ms4a4a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000304 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000304">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000881"/>
+        <obo:PCL_0000100>PVM_2</obo:PCL_0000100>
+        <id>pCL_0000304</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cd74-expressing mouse primary motor cortex perivascular macrophage</preferred_name>
+        <prefixIRI>pCL:0000304</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken204</tdc_id>
+        <rdfs:label>Cd74-expressing mouse primary motor cortex perivascular macrophage</rdfs:label>
+        <skos:definition>is a Cd74-expressing mouse primary motor cortex perivascular macrophage that selectively expresses Cd74, and Klra2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000881"/>
+        <obo:PCL_0000100>PVM_3</obo:PCL_0000100>
+        <id>pCL_0000305</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cd209a-expressing mouse primary motor cortex perivascular macrophage</preferred_name>
+        <prefixIRI>pCL:0000305</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken205</tdc_id>
+        <rdfs:label>Cd209a-expressing mouse primary motor cortex perivascular macrophage</rdfs:label>
+        <skos:definition>is a Cd209a-expressing mouse primary motor cortex perivascular macrophage that selectively expresses Cd209a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000306 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000306">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:2000043"/>
+        <obo:PCL_0000100>Peri</obo:PCL_0000100>
+        <id>pCL:0000306</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Abcc9-expressing mouse primary motor cortex brain pericyte</preferred_name>
+        <prefixIRI>pCL:0000306</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken206</tdc_id>
+        <rdfs:label>Abcc9-expressing mouse primary motor cortex brain pericyte</rdfs:label>
+        <skos:definition>is a Abcc9-expressing mouse primary motor cortex brain pericyte  that selectively expresses Abcc9, and Tbx3os1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000307 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000307">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Calb1_1</obo:PCL_0000100>
+        <id>pCL:0000307</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cort-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000307</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken207</tdc_id>
+        <rdfs:label>Cort-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cort-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Cort, and Gm28807, and Nxph2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000308 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000308">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Calb1_2</obo:PCL_0000100>
+        <id>pCL:0000308</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cntnap5c-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000308</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken208</tdc_id>
+        <rdfs:label>Cntnap5c-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cntnap5c-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Cntnap5c, and Tac1, and Tmem132c mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000309 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000309">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Egfem1</obo:PCL_0000100>
+        <id>pCL:0000309</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Plch1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000309</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken209</tdc_id>
+        <rdfs:label>Plch1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Plch1-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses 9330158H04Rik, and Plch1, and Tac1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000310 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000310">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Gabrg1</obo:PCL_0000100>
+        <id>pCL:0000310</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Gabrg1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000310</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken210</tdc_id>
+        <rdfs:label>Gabrg1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Gabrg1-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Gabrg1, and Th mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000311 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000311">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Gpr149</obo:PCL_0000100>
+        <id>pCL_00000311</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Fzd6-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000311</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken211</tdc_id>
+        <rdfs:label>Fzd6-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Fzd6-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Fzd6, and Slit2, and Syt2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000312 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000312">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Il1rapl2</obo:PCL_0000100>
+        <id>pCL:0000312</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Eya4-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000312</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken212</tdc_id>
+        <rdfs:label>Eya4-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Eya4-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Eya4, and Il1rapl2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000313 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000313">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Kank4</obo:PCL_0000100>
+        <id>pCL:0000313</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cacna2d2-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000313</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken213</tdc_id>
+        <rdfs:label>Cacna2d2-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cacna2d2-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Cacna2d2, and Sema3e, and Syt2, and Tmem132d mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000314 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000314">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Reln</obo:PCL_0000100>
+        <id>pCL:0000314</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cntnap4-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000314</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken214</tdc_id>
+        <rdfs:label>Cntnap4-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cntnap4-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Cntnap4, and Gm46102 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000315 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000315">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Vipr2_1</obo:PCL_0000100>
+        <id>pCL:0000315</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Lamb1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000315</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken215</tdc_id>
+        <rdfs:label>Lamb1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Lamb1-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Lamb1, and Nkx2_1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000316 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000316">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Pvalb Vipr2_2</obo:PCL_0000100>
+        <id>pCL:0000316</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cntnap5b-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000316</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken216</tdc_id>
+        <rdfs:label>Cntnap5b-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cntnap5b-expressing mouse primary motor cortex PVALB GABAergic interneuron that selectively expresses Cntnap5b, and Unc5b mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000318 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000318">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Sncg Calb1_1</obo:PCL_0000100>
+        <id>pCL:0000318</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Krt73-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000318</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken218</tdc_id>
+        <rdfs:label>Krt73-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Krt73-expressing mouse primary motor cortex SNCG GABAergic interneuron that selectively expresses Krt73, and Sln, and Syt6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000319 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000319">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Sncg Calb1_2</obo:PCL_0000100>
+        <id>pCL:0000319</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Calb1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000319</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken219</tdc_id>
+        <rdfs:label>Calb1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Calb1-expressing mouse primary motor cortex SNCG GABAergic interneuron that selectively expresses Calb1, and Epb41l4a, and Syt6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000320 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000320">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Sncg Col14a1</obo:PCL_0000100>
+        <id>pCL:0000320</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cdh6-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000320</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken220</tdc_id>
+        <rdfs:label>Cdh6-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cdh6-expressing mouse primary motor cortex SNCG GABAergic interneuron that selectively expresses Cdh6, and Col25a1, and Eps8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000321 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000321">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Sncg Npy2r</obo:PCL_0000100>
+        <id>pCL:0000321</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Npy2r-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000321</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken221</tdc_id>
+        <rdfs:label>Npy2r-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Npy2r-expressing mouse primary motor cortex SNCG GABAergic interneuron that selectively expresses Npy2r, and Rgs12 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000322 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000322">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Sncg Slc17a8</obo:PCL_0000100>
+        <id>pCL:0000322</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Slc17a8-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000322</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken222</tdc_id>
+        <rdfs:label>Slc17a8-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Slc17a8-expressing mouse primary motor cortex SNCG GABAergic interneuron that selectively expresses Slc17a8, and Yjefn3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000323 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000323">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst C1ql3_1</obo:PCL_0000100>
+        <id>pCL:0000323</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pard3b-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000323</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken223</tdc_id>
+        <rdfs:label>Pard3b-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Pard3b-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Gm48893, and Pard3b mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000324 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000324">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst C1ql3_2</obo:PCL_0000100>
+        <id>pCL:0000324</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Brinp3-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000324</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken224</tdc_id>
+        <rdfs:label>Brinp3-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Brinp3-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Brinp3, and Gxylt2, and Ndnf mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000325 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000325">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Calb2</obo:PCL_0000100>
+        <id>pCL:0000325</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Olfm3-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000325</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken225</tdc_id>
+        <rdfs:label>Olfm3-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Olfm3-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Olfm3, and Sst mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000326 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000326">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000116"/>
+        <obo:PCL_0000100>Sst Chodl</obo:PCL_0000100>
+        <id>pCL:0000326</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Nos1-expressing mouse primary motor cortexGABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000326</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken226</tdc_id>
+        <rdfs:label>Nos1-expressing mouse primary motor cortexGABAergic interneuron</rdfs:label>
+        <skos:definition>is a Nos1-expressing mouse primary motor cortex SST CHODL GABAergic interneuron that selectively expresses Nos1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000327 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000327">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Crhr2_1</obo:PCL_0000100>
+        <id>pCL:0000327</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Trpc6-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000327</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken227</tdc_id>
+        <rdfs:label>Trpc6-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Trpc6-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Eya4, and Nek7, and Trpc6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000328 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000328">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Crhr2_2</obo:PCL_0000100>
+        <id>pCL:0000328</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Lypd6b-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000328</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken228</tdc_id>
+        <rdfs:label>Lypd6b-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Lypd6b-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Lypd6b, and Trpc6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000329 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000329">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Etv1</obo:PCL_0000100>
+        <id>pCL:0000329</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Col19a1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000329</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken229</tdc_id>
+        <rdfs:label>Col19a1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Col19a1-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Col19a1, and Fbn2, and Trpc6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000330 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000330">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Hpse</obo:PCL_0000100>
+        <id>pCL:0000330</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Hpse-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000330</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken230</tdc_id>
+        <rdfs:label>Hpse-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Hpse-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Hpse, and Rerg mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000331 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000331">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Htr1a</obo:PCL_0000100>
+        <id>pCL:0000331</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pdyn-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000331</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken231</tdc_id>
+        <rdfs:label>Pdyn-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Pdyn-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Gm30835, and Pdyn mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000332 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000332">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Myh8_1</obo:PCL_0000100>
+        <id>pCL:0000332</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Il1rapl2-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000332</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken232</tdc_id>
+        <rdfs:label>Il1rapl2-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Il1rapl2-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Il1rapl2, and Reln mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000333 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000333">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Myh8_2</obo:PCL_0000100>
+        <id>pCL:0000333</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cdh13-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000333</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken233</tdc_id>
+        <rdfs:label>Cdh13-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cdh13-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Cdh13, and Pld5, and Sox6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000334 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000334">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Myh8_3</obo:PCL_0000100>
+        <id>pCL:0000334</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cdh9-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000334</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken234</tdc_id>
+        <rdfs:label>Cdh9-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Cdh9-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Cdh9, and Grm1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000335 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000335">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Penk</obo:PCL_0000100>
+        <id>pCL:0000335</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Cartpt-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000335</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken235</tdc_id>
+        <rdfs:label>Cartpt-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a 9530026P05Rik-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses 9530026P05Rik, and Cartpt, and Il1rapl2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000336 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000336">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Pvalb Calb2</obo:PCL_0000100>
+        <id>pCL:0000336</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Moxd1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000336</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken236</tdc_id>
+        <rdfs:label>Moxd1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Moxd1-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Moxd1, and Prkg2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000337 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000337">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Pvalb Etv1</obo:PCL_0000100>
+        <id>pCL:0000337</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Edaradd-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000337</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken237</tdc_id>
+        <rdfs:label>Edaradd-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Edaradd-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Edaradd, and Spon1, and Whrn mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000338 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000338">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Tac2</obo:PCL_0000100>
+        <id>pCL:0000338</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Tmtc2-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000338</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken238</tdc_id>
+        <rdfs:label>Tmtc2-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Tmtc2-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Cdh13, and Tac2, and Tmtc2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000339 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000339">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Th_1</obo:PCL_0000100>
+        <id>pCL:0000339</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>St6galnac5-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000339</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken239</tdc_id>
+        <rdfs:label>St6galnac5-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a St6galnac5-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses St6galnac5, and St8sia4, and Zfpm2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000340 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000340">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Th_2</obo:PCL_0000100>
+        <id>pCL:0000340</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pnoc-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000340</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken240</tdc_id>
+        <rdfs:label>Pnoc-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Pnoc-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Pard3b, and Pnoc, and Sst mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000341 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000341">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Th_3</obo:PCL_0000100>
+        <id>pCL:0000341</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Th-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000341</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken241</tdc_id>
+        <rdfs:label>Th-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Th-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses Cort, and Th mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000342 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000342">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Sst Pappa</obo:PCL_0000100>
+        <id>pCL:0000342</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>AC129186_1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000342</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken242</tdc_id>
+        <rdfs:label>AC129186_1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a AC129186_1-expressing mouse primary motor cortex SST GABAergic interneuron that selectively expresses AC129186_1, and Trpc6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000343 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000343">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_1</obo:PCL_0000100>
+        <id>pCL_0000343</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Col4a6-expressing mouse primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000343</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken243</tdc_id>
+        <rdfs:label>Col4a6-expressing mouse primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a Col4a6-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Col4a6, and Gm30624, and Itih5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000344 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000344">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_2</obo:PCL_0000100>
+        <id>pCL_0000344</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Aox3-expressing mouse primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000344</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken244</tdc_id>
+        <rdfs:label>Aox3-expressing mouse primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a Aox3-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Aox3, and Lama1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000345 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000345">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_3</obo:PCL_0000100>
+        <id>pCL_0000345</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pkhd1-expressing mouse primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000345</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken245</tdc_id>
+        <rdfs:label>Pkhd1-expressing mouse primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a Pkhd1-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Pkhd1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000346 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000346">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_4</obo:PCL_0000100>
+        <id>pCL_0000346</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Prdm6-expressing mouse primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000346</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken246</tdc_id>
+        <rdfs:label>Prdm6-expressing mouse primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a Prdm6-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Prdm6, and Slc6a20a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000347 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000347">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_5</obo:PCL_0000100>
+        <id>pCL_0000347</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Slc47a1-expressing mouse primary motor cortex vascular leptomeningeal cells</preferred_name>
+        <prefixIRI>pCL:0000347</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken247</tdc_id>
+        <rdfs:label>Slc47a1-expressing mouse primary motor cortex vascular leptomeningeal cells</rdfs:label>
+        <skos:definition>is a Slc47a1-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Slc47a1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000348 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000348">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_6</obo:PCL_0000100>
+        <id>pCL_0000348</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Dapl1-expressing mouse primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000348</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken248</tdc_id>
+        <rdfs:label>Dapl1-expressing mouse primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a Dapl1-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Dapl1, and Prg4, and Slc26a7 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000349 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000349">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC_7</obo:PCL_0000100>
+        <id>pCL_0000349</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Dapl1-expressing mouse primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000349</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken249</tdc_id>
+        <rdfs:label>Tspan8-expressing mouse primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a Tspan8-expressing mouse primary motor cortex vascular leptomeningeal cell that selectively expresses Dapl1, and Tspan8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000350 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000350">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip C1ql1</obo:PCL_0000100>
+        <id>pCL:0000350</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Bmper-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000350</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken250</tdc_id>
+        <rdfs:label>Bmper-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Bmper-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Bmper, and Btbd11, and Crh, and Vip mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000351 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000351">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Chat_1</obo:PCL_0000100>
+        <id>pCL:0000351</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Chat-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000351</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken251</tdc_id>
+        <rdfs:label>Chat-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Chat-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Chat, and Npy2r mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000352 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000352">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Chat_2</obo:PCL_0000100>
+        <id>pCL:0000352</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Grik4-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000352</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken252</tdc_id>
+        <rdfs:label>Grik4-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Grik4-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Grik4, and Htr4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000353 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000353">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Gpc3</obo:PCL_0000100>
+        <id>pCL:0000353</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pbx3-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000353</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken253</tdc_id>
+        <rdfs:label>Pbx3-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Pbx3-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Pbx3, and Pde3a, and Vip mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000354 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000354">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Htr1f</obo:PCL_0000100>
+        <id>pCL:0000354</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Nov-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000354</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken254</tdc_id>
+        <rdfs:label>Nov-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Nov-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Nov, and Vip, and Vwc2l mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000355 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000355">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Igfbp6_1</obo:PCL_0000100>
+        <id>pCL:0000355</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Thsd7a-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000355</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken255</tdc_id>
+        <rdfs:label>Thsd7a-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Thsd7a-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Gm39185, and Thsd7a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000356 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000356">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Igfbp6_2</obo:PCL_0000100>
+        <id>pCL:0000356</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Crh-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000356</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken256</tdc_id>
+        <rdfs:label>Crh-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Crh-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Crh, and Thsd7b mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000357 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000357">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Mybpc1_1</obo:PCL_0000100>
+        <id>pCL:0000357</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Calb2-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000357</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken257</tdc_id>
+        <rdfs:label>Calb2-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Calb2-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Calb2, and Gm2516 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000358 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000358">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Mybpc1_2</obo:PCL_0000100>
+        <id>pCL:0000358</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Htr3a-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000358</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken258</tdc_id>
+        <rdfs:label>Htr3a-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Htr3a-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses 5033421B08Rik, and Htr3a mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000359 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000359">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Mybpc1_3</obo:PCL_0000100>
+        <id>pCL:0000359</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Caln1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000359</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken259</tdc_id>
+        <rdfs:label>Caln1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Caln1-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Caln1, and Grm8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000360 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000360">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Serpinf1_1</obo:PCL_0000100>
+        <id>pCL:0000360</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Rgs16-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000360</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken260</tdc_id>
+        <rdfs:label>Rgs16-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Rgs16-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Rgs16, and Sfrp2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000361 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000361">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Serpinf1_2</obo:PCL_0000100>
+        <id>pCL:0000361</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Col14a1-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000361</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken261</tdc_id>
+        <rdfs:label>Col14a1-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Col14a1-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Col14a1, and Nov, and Pbx3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000362 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000362">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Serpinf1_3</obo:PCL_0000100>
+        <id>pCL:0000362</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Enpp2-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000362</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken262</tdc_id>
+        <rdfs:label>Enpp2-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Enpp2-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Enpp2, and Homer2, and Nov, and Plekhg1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000363 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000363">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Vip Sncg</obo:PCL_0000100>
+        <id>pCL:0000363</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Enpp2-expressing mouse primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000363</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken263</tdc_id>
+        <rdfs:label>Nectin3-expressing mouse primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a Crh-expressing mouse primary motor cortex VIP GABAergic interneuron that selectively expresses Crh, and Nectin3, and Unc5b mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000364 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000364">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <id>pCL_00000364</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <preferred_name>Meis2 expressing glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000364</prefixIRI>
+        <rdfs:label>Meis2 expressing glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Meis2 expressing glutamatergic neuron</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000366 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000366">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>L5 PT_1</obo:PCL_0000100>
+        <id>pCL_00000255</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Crym-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000255</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken155</tdc_id>
+        <rdfs:label>Crym-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Crym-expressing mouse primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses Crym, and Gm2164, and Npr3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000368 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000368">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro FGFR3 EPHB1</obo:PCL_0000100>
+        <id>pCL_0000368</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ETNPPL-expressing marmoset primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000368</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken264</tdc_id>
+        <rdfs:label>ETNPPL-expressing marmoset primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a ETNPPL-expressing marmoset primary motor cortex astrocyte that selectively expresses ETNPPL, and MOXD1, and PLEKHA7 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000369 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000369">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro FGFR3 GFAP</obo:PCL_0000100>
+        <id>pCL_0000369</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GFAP-expressing marmoset primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000369</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken265</tdc_id>
+        <rdfs:label>GFAP-expressing marmoset primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a GFAP-expressing marmoset primary motor cortex astrocyte that selectively expresses GFAP mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000370 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000370">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro FGFR3 NWD1</obo:PCL_0000100>
+        <id>pCL_0000370</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CCDC129-expressing marmoset primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000370</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken266</tdc_id>
+        <rdfs:label>CCDC129-expressing marmoset primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a CCDC129-expressing marmoset primary motor cortex astrocyte that selectively expresses CCDC129, and LOC100406856, and LOC108587679, and NWD1, and SLC1A2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000371 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000371">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <obo:PCL_0000100>Astro FGFR3 RCN2</obo:PCL_0000100>
+        <id>pCL_0000371</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>BMPR1B-expressing marmoset primary motor cortex astrocyte</preferred_name>
+        <prefixIRI>pCL:0000371</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken267</tdc_id>
+        <rdfs:label>BMPR1B-expressing marmoset primary motor cortex astrocyte</rdfs:label>
+        <skos:definition>is a BMPR1B-expressing marmoset primary motor cortex astrocyte that selectively expresses BMPR1B, and CCDC129, and FABP7, and MOXD1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000372 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000372">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602"/>
+        <obo:PCL_0000100>Endo NOSTRIN CXCL12</obo:PCL_0000100>
+        <id>pCL_0000372</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MECOM-expressing marmoset primary motor cortex endothelial cell</preferred_name>
+        <prefixIRI>pCL:0000372</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken268</tdc_id>
+        <rdfs:label>MECOM-expressing marmoset primary motor cortex endothelial cell</rdfs:label>
+        <skos:definition>is a MECOM-expressing marmoset primary motor cortex endothelial cell that selectively expresses MECOM, and SLC7A5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000373 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000373">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602"/>
+        <obo:PCL_0000100>Endo NOSTRIN IL1R1</obo:PCL_0000100>
+        <id>pCL_0000373</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADGRG6-expressing marmoset primary motor cortex endothelial cell</preferred_name>
+        <prefixIRI>pCL:0000373</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken269</tdc_id>
+        <rdfs:label>ADGRG6-expressing marmoset primary motor cortex endothelial cell</rdfs:label>
+        <skos:definition>is a ADGRG6-expressing marmoset primary motor cortex endothelial cell that selectively expresses ADGRG6, and IL1R1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000374 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000374">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000112"/>
+        <obo:PCL_0000100>Exc FEZF2 ARSJ</obo:PCL_0000100>
+        <id>pCL_00000374</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>THSD4-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000374</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken270</tdc_id>
+        <rdfs:label>THSD4-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a THSD4-expressing marmoset primary motor cortical layer 6b glutamatergic neuron that selectively expresses HS3ST4, and THSD4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000375 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000375">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>Exc FEZF2 CRYM</obo:PCL_0000100>
+        <id>pCL_00000375</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CHRM2-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000375</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken271</tdc_id>
+        <rdfs:label>CHRM2-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CHRM2-expressing marmoset primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses CHRM2, and HMCN1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000376 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000376">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc FEZF2 NRP1</obo:PCL_0000100>
+        <id>pCL_00000376</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NRP1-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000376</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken272</tdc_id>
+        <rdfs:label>NRP1-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a NRP1-expressing marmoset primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses HS3ST4, and NRP1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000377 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000377">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>Exc FEZF2 PDZRN4</obo:PCL_0000100>
+        <id>pCL_00000377</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ERG-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000377</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken273</tdc_id>
+        <rdfs:label>ERG-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ERG-expressing marmoset primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses ERG, and PDZRN4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000378 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000378">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>Exc FEZF2 PIEZO2</obo:PCL_0000100>
+        <id>pCL_00000378</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FBN2-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000378</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken274</tdc_id>
+        <rdfs:label>FBN2-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a FBN2-expressing marmoset primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses FBN2, and LOC103793569 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000379 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000379">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000109"/>
+        <obo:PCL_0000100>Exc FEZF2 RGS4</obo:PCL_0000100>
+        <id>pCL_00000379</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>BMP5-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000379</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken275</tdc_id>
+        <rdfs:label>BMP5-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a BMP5-expressing marmoset primary motor cortical layer 6 corticothalamic glutamatergic neuron that selectively expresses BMP5, and HS3ST4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000380 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000380">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB ACTA2</obo:PCL_0000100>
+        <id>pCL_00000380</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FOXP2-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000380</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken276</tdc_id>
+        <rdfs:label>FOXP2-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a FOXP2-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses FOXP2, and RORB, and VWC2L mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000382 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000382">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB CAV3</obo:PCL_0000100>
+        <id>pCL_00000382</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC100408486-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000382</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken278</tdc_id>
+        <rdfs:label>LOC100408486-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a LOC100408486-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses LOC100408486 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000383 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000383">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB CHGA</obo:PCL_0000100>
+        <id>pCL_00000383</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>HS3ST4-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000383</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken279</tdc_id>
+        <rdfs:label>HS3ST4-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a HS3ST4-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses HS3ST4, and RCSD1, and RORB, and TOX mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000384 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000384">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB HACL1</obo:PCL_0000100>
+        <id>pCL_00000384</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>AMOTL1-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000384</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken280</tdc_id>
+        <rdfs:label>AMOTL1-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a AMOTL1-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses AMOTL1, and CMTM8, and FAM19A1, and NRG1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000385 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000385">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB KNL1</obo:PCL_0000100>
+        <id>pCL_00000385</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>VAV3-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000385</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken281</tdc_id>
+        <rdfs:label>VAV3-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a VAV3-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses VAV3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000386 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000386">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc RORB LOC108588466</obo:PCL_0000100>
+        <id>pCL_00000386</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ARHGAP10-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000386</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken282</tdc_id>
+        <rdfs:label>ARHGAP10-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a ARHGAP10-expressing marmoset primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses ARHGAP10, and LOC108588466, and PDZD2, and RGS6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000387 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000387">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB LOC108593203</obo:PCL_0000100>
+        <id>pCL_00000387</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>VWC2L-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000387</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken283</tdc_id>
+        <rdfs:label>VWC2L-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a VWC2L-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses LOC108593203, and VWC2L mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000388 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000388">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc RORB NDST3</obo:PCL_0000100>
+        <id>pCL_00000388</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CHST9-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000388</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken284</tdc_id>
+        <rdfs:label>CHST9-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CHST9-expressing marmoset primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses CHST9, and DGKG, and KIAA2012 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000389 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000389">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB PPA2</obo:PCL_0000100>
+        <id>pCL_00000389</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EYA4-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000389</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken285</tdc_id>
+        <rdfs:label>EYA4-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EYA4-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses EYA4, and HS3ST4, and LOC108588895 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000390 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000390">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc RORB SERPINE2</obo:PCL_0000100>
+        <id>pCL_00000390</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CHST8-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000390</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken286</tdc_id>
+        <rdfs:label>CHST8-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CHST8-expressing marmoset primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses CHST8, and PLA2G4A, and SNTB2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000391 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000391">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB SLC38A11</obo:PCL_0000100>
+        <id>pCL_00000391</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TOX-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000391</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken287</tdc_id>
+        <rdfs:label>TOX-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TOX-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses FOXP2, and SLC38A11, and TOX mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000392 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000392">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000107"/>
+        <obo:PCL_0000100>Exc RORB USH1C</obo:PCL_0000100>
+        <id>pCL_00000392</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SPON1-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000392</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken288</tdc_id>
+        <rdfs:label>SPON1-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SPON1-expressing marmoset primary motor cortical layer 5 intratelencephalic glutamatergic neuron that selectively expresses SPON1, and TMEM163, and USH1C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000393 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000393">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000105"/>
+        <obo:PCL_0000100>Exc THEMIS ANO3</obo:PCL_0000100>
+        <id>pCL_00000393</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLC38A11-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000393</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken289</tdc_id>
+        <rdfs:label>SLC38A11-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC38A11-expressing marmoset primary motor cortical layer 2/3 intratelencephalic glutamatergic neuron that selectively expresses CHST9, and NPFFR2, and SLC38A11, and SLIT3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000394 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000394">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000106"/>
+        <obo:PCL_0000100>Exc THEMIS ARL13B</obo:PCL_0000100>
+        <id>pCL_00000394</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EPB41L4A-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000394</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken290</tdc_id>
+        <rdfs:label>EPB41L4A-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EPB41L4A-expressing marmoset primary motor cortical layer 5 extratelencephalic glutamatergic neuron that selectively expresses EPB41L4A, and SV2C, and THEMIS mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000395 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000395">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>Exc THEMIS COBL</obo:PCL_0000100>
+        <id>pCL_00000395</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CNR1-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000395</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken291</tdc_id>
+        <rdfs:label>CNR1-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CNR1-expressing marmoset primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses CNR1, and GABRG1, and IQGAP2, and NFIA mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000396 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000396">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000111"/>
+        <obo:PCL_0000100>Exc THEMIS KCTD16</obo:PCL_0000100>
+        <id>pCL_00000396</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CSGALNACT1-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000396</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken292</tdc_id>
+        <rdfs:label>CSGALNACT1-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CSGALNACT1-expressing marmoset primary motor cortical layer 6 intratelencephalic glutamatergic neuron that selectively expresses CSGALNACT1, and PLXDC2, and PTPRK, and THEMIS mRNAss</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000397 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000397">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000110"/>
+        <obo:PCL_0000100>Exc THEMIS NTNG2</obo:PCL_0000100>
+        <id>pCL_00000397</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NTNG2-expressing marmoset primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000397</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken293</tdc_id>
+        <rdfs:label>NTNG2-expressing marmoset primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a NTNG2-expressing marmoset primary motor cortex layer 6 intratelencephalic Car3 glutamatergic neuron that selectively expresses NTNG2, and PTPRU mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000398 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000398">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602"/>
+        <obo:PCL_0000100>Glia SLC1A3 FBLN5</obo:PCL_0000100>
+        <id>pCL_0000398</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FBLN5-expressing marmoset primary motor cortex endothelial</preferred_name>
+        <prefixIRI>pCL:0000398</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken294</tdc_id>
+        <rdfs:label>FBLN5-expressing marmoset primary motor cortex endothelial</rdfs:label>
+        <skos:definition>is a FBLN5-expressing marmoset primary motor cortex endothelial cell that selectively expresses FBLN5 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000399 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000399">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh GAD1 LOC108589948</obo:PCL_0000100>
+        <id>pCL_0000399</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>THSD7B-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000399</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken295</tdc_id>
+        <rdfs:label>THSD7B-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a THSD7B-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses LOC108589948, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000400 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000400">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh GAD1 NPSR1</obo:PCL_0000100>
+        <id>pCL_0000400</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ALCAM-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000400</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken296</tdc_id>
+        <rdfs:label>ALCAM-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ALCAM-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses ALCAM, and LOC100403193 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000401 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000401">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh GAD1 PCP4</obo:PCL_0000100>
+        <id>pCL_0000401</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PATJ-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000401</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken297</tdc_id>
+        <rdfs:label>PATJ-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PATJ-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses PATJ, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000402 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000402">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh LAMP5 COL5A2</obo:PCL_0000100>
+        <id>pCL_0000402</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GLIS3-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000402</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken298</tdc_id>
+        <rdfs:label>GLIS3-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GLIS3-expressing marmoset primary motor cortex LAMP5 GABAergic interneuron that selectively expresses GLIS3, and TOX3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000403 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000403">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh LAMP5 LOC108591196</obo:PCL_0000100>
+        <id>pCL_0000403</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>COL25A1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000403</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken299</tdc_id>
+        <rdfs:label>COL25A1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a COL25A1-expressing marmoset primary motor cortex LAMP5 GABAergic interneuron that selectively expresses COL25A1, and KIT mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000404 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000404">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh LAMP5 TOX2</obo:PCL_0000100>
+        <id>pCL_0000404</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ALK-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000404</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken300</tdc_id>
+        <rdfs:label>ALK-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ALK-expressing marmoset primary motor cortex LAMP5 GABAergic interneuron that selectively expresses ALK, and RELN, and TOX2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000405 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000405">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh LAMP5 TRPC6</obo:PCL_0000100>
+        <id>pCL_0000405</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TACR1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000405</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken301</tdc_id>
+        <rdfs:label>TACR1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a TACR1-expressing marmoset primary motor cortex LAMP5 GABAergic interneuron that selectively expresses TACR1, and TRPC6 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000406 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000406">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh LAMP5 WWP1</obo:PCL_0000100>
+        <id>pCL_0000406</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NTNG1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000406</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken302</tdc_id>
+        <rdfs:label>NTNG1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KIT-expressing marmoset primary motor cortex LAMP5 GABAergic interneuron that selectively expresses KIT, and NTNG1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000407 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000407">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh PAX6 ANKRD6</obo:PCL_0000100>
+        <id>pCL_0000407</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FBN2-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000407</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken303</tdc_id>
+        <rdfs:label>FBN2-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBN2-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses FBN2, and GPRIN3, and SPACA1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000408 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000408">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh PAX6 CDH4</obo:PCL_0000100>
+        <id>pCL_0000408</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ARHGAP6-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000408</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken304</tdc_id>
+        <rdfs:label>ARHGAP6-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ARHGAP6-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses ARHGAP6, and CDH4, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000409 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000409">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh PAX6 HMBOX1</obo:PCL_0000100>
+        <id>pCL_0000409</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>RELN-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000409</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken305</tdc_id>
+        <rdfs:label>RELN-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a RELN-expressing marmoset primary motor cortex LAMP5 GABAergic interneuron that selectively expresses RELN, and SORCS3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000410 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000"/>
+        <obo:PCL_0000100>Inh PAX6 MEIS2</obo:PCL_0000100>
+        <id>pCL_0000410</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PBX3-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000410</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken306</tdc_id>
+        <rdfs:label>PBX3-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PBX3-expressing marmoset primary motor cortex Meis2 GABAergic interneuron that selectively expresses PBX3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000411 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000411">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB ADAMTS3</obo:PCL_0000100>
+        <id>pCL_0000411</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KCNK13-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000411</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken307</tdc_id>
+        <rdfs:label>KCNK13-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KCNK13-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses KCNK13, and SYT10, and TMEM132C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000412 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000412">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB C8H7orf62</obo:PCL_0000100>
+        <id>pCL_0000412</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CHST9-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000412</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken308</tdc_id>
+        <rdfs:label>CHST9-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CHST9-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses CHST9, and LRRC38, and SULF1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000413 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000413">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB FAM19A4</obo:PCL_0000100>
+        <id>pCL_0000413</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FAM19A1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000413</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken309</tdc_id>
+        <rdfs:label>FAM19A1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FAM19A1-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses FAM19A1, and POSTN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000414 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000414">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB GSTK1</obo:PCL_0000100>
+        <id>pCL_0000414</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EYS-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000414</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken310</tdc_id>
+        <rdfs:label>EYS-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EYS-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses EYS, and MYO5B, and POSTN, and SULF1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000415 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000415">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB KLHL29</obo:PCL_0000100>
+        <id>pCL_0000415</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ABCB4-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000415</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken311</tdc_id>
+        <rdfs:label>ABCB4-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ABCB4-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses ABCB4, and RNF144B, and SLIT2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000416 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000416">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB LOC103789439</obo:PCL_0000100>
+        <id>pCL_0000416</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CALN1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000416</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken312</tdc_id>
+        <rdfs:label>CALN1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CALN1-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses CALN1, and FAM179A, and FILIP1, and SULF1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000417 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000417">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB LOC103790362</obo:PCL_0000100>
+        <id>pCL_0000417</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FILIP1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000417</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken313</tdc_id>
+        <rdfs:label>FILIP1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FILIP1-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses COL25A1, and FILIP1, and PRKG1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000418 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000418">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB OSBP2</obo:PCL_0000100>
+        <id>pCL_0000418</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>B3GLCT-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000418</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken314</tdc_id>
+        <rdfs:label>B3GLCT-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a B3GLCT-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses B3GLCT, and BTBD11, and MYO5B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000419 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000419">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB OTOGL</obo:PCL_0000100>
+        <id>pCL_0000419</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CCDC141-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000419</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken315</tdc_id>
+        <rdfs:label>CCDC141-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CCDC141-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses CCDC141, and CHRM2, and POSTN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000420 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000420">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB PCDH19</obo:PCL_0000100>
+        <id>pCL_0000420</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CPNE8-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000420</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken316</tdc_id>
+        <rdfs:label>CPNE8-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CPNE8-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses CPNE8, and LOC103788721, and POSTN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000421 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000421">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh PVALB SST EYS</obo:PCL_0000100>
+        <id>pCL_0000421</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>POSTN-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000421</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken317</tdc_id>
+        <rdfs:label>POSTN-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a EYS-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses EYS, and LOC103788721, and POSTN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000422 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000422">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh PVALB SST LRRC6</obo:PCL_0000100>
+        <id>pCL_0000422</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TOX2-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000422</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken318</tdc_id>
+        <rdfs:comment>PVALB expressing cell that clusters within SST clade</rdfs:comment>
+        <rdfs:label>TOX2-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a TOX2-expressing marmoset primary motor cortex PVALB GABAergic interneuron that selectively expresses COL25A1, and EYS, and NOS1, and TOX2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000423 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000423">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh SNCG CNTN4</obo:PCL_0000100>
+        <id>pCL_0000423</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ARHGAP18-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000423</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken319</tdc_id>
+        <rdfs:label>ARHGAP18-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ARHGAP18-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses ARHGAP18, and PCDH15, and VEGFC mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000424 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000424">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh SNCG LOC108587895</obo:PCL_0000100>
+        <id>pCL_0000424</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ADARB2-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000424</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken320</tdc_id>
+        <rdfs:label>ADARB2-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ADARB2-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses ADARB2, and LOC103793609, and SEMA3C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000425 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000425">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh SNCG PLPPR1</obo:PCL_0000100>
+        <id>pCL_0000425</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CNR1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000425</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken321</tdc_id>
+        <rdfs:label>CNR1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CNR1-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses CNR1, and TRPM3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000426 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000426">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST ABI3BP</obo:PCL_0000100>
+        <id>pCL_0000426</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ABI3BP-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000426</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken322</tdc_id>
+        <rdfs:label>ABI3BP-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ABI3BP-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses ABI3BP, and LOC100401328 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000427 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000427">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST AIM1</obo:PCL_0000100>
+        <id>pCL_0000427</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NELL1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000427</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken323</tdc_id>
+        <rdfs:label>NELL1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a NELL1-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses NELL1, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000428 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000428">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST CBLN4</obo:PCL_0000100>
+        <id>pCL_0000428</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CBLN4-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000428</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken324</tdc_id>
+        <rdfs:label>CBLN4-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CBLN4-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses CBLN4, and COL24A1 mRNAssses NELL1, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000429 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000429">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST KIRREL3</obo:PCL_0000100>
+        <id>pCL_0000429</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SERPINI1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000429</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken325</tdc_id>
+        <rdfs:label>SERPINI1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SERPINI1-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses COL25A1, and PTPRT, and SERPINI1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000430 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000430">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST LOC103788138</obo:PCL_0000100>
+        <id>pCL_0000430</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>GLRA3-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000430</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken326</tdc_id>
+        <rdfs:label>GLRA3-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GLRA3-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses ALK, and GLRA3, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000431 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000431">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST LOC103788660</obo:PCL_0000100>
+        <id>pCL_0000431</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NXPH1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000431</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken327</tdc_id>
+        <rdfs:label>NXPH1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a NXPH1-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses COL24A1, and COL25A1, and NXPH1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000432 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000432">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST LOC108588801</obo:PCL_0000100>
+        <id>pCL_0000432</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>PCDH11X-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000432</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken328</tdc_id>
+        <rdfs:label>PCDH11X-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PCDH11X-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses COL25A1, and LOC108588801, and PCDH11X mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000433 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000433">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST LOC108589054</obo:PCL_0000100>
+        <id>pCL_0000433</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SULF1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000433</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken329</tdc_id>
+        <rdfs:label>SULF1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SULF1-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses SULF1, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000434 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000434">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST LTBP1</obo:PCL_0000100>
+        <id>pCL_0000434</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TRHDE-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000434</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken330</tdc_id>
+        <rdfs:label>TRHDE-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a TRHDE-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses COL12A1, and TRHDE mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000435 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000435">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST MPP5</obo:PCL_0000100>
+        <id>pCL_0000435</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ARHGAP24-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000435</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken331</tdc_id>
+        <rdfs:label>ARHGAP24-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ARHGAP24-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses ARHGAP24, and SYT9, and TAC1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000436 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000436">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000116"/>
+        <obo:PCL_0000100>Inh SST NPY</obo:PCL_0000100>
+        <id>pCL_0000436</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>POSTN-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000436</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken332</tdc_id>
+        <rdfs:label>NPY-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a NPY-expressing marmoset primary motor cortex SST CHODL GABAergic interneuron that selectively expresses NPY mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000437 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000437">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST P4HA1</obo:PCL_0000100>
+        <id>pCL_0000437</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>KCTD8-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000437</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken333</tdc_id>
+        <rdfs:label>KCTD8-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a KCTD8-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses ABI3BP, and COL19A1, and KCTD8 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000438 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000438">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST PCSK5</obo:PCL_0000100>
+        <id>pCL_0000438</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>NCKAP5-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000438</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken334</tdc_id>
+        <rdfs:label>NCKAP5-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a NCKAP5-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses NCKAP5, and RELN, and UNC13C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000439 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000439">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST TMEFF2</obo:PCL_0000100>
+        <id>pCL_0000439</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MAN1A1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000439</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken335</tdc_id>
+        <rdfs:label>MAN1A1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a MAN1A1-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses ANKRD55, and LOC100384959, and MAN1A1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000440 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000440">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh SST VAPA</obo:PCL_0000100>
+        <id>pCL_0000440</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC103793609-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000440</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken336</tdc_id>
+        <rdfs:label>LOC103793609-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a LOC103793609-expressing marmoset primary motor cortex SST GABAergic interneuron that selectively expresses EYS, and LOC103793609 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000441 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000441">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP CIT</obo:PCL_0000100>
+        <id>pCL_0000441</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>EGFR-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000441</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken337</tdc_id>
+        <rdfs:label>EGFR-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ARHGAP18-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses ARHGAP18, and EGFR, and FREM1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000442 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000442">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000115"/>
+        <obo:PCL_0000100>Inh VIP CYP19A1</obo:PCL_0000100>
+        <id>pCL_0000442</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SKAP1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000442</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken338</tdc_id>
+        <rdfs:label>SKAP1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SKAP1-expressing marmoset primary motor cortex SNCG GABAergic interneuron that selectively expresses LOC103795617, and SKAP1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000443 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000443">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP FIGN</obo:PCL_0000100>
+        <id>pCL_0000443</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CALB2-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000443</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken339</tdc_id>
+        <rdfs:label>CALB2-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CALB2-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses CALB2, and PCSK6, and UNC13C mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000444 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000444">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP GPR149</obo:PCL_0000100>
+        <id>pCL_0000444</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CREB5-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000444</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken340</tdc_id>
+        <rdfs:label>CREB5-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CREB5-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses CREB5, and CRH mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000445 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000445">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP LOC100397259</obo:PCL_0000100>
+        <id>pCL_0000445</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CRH-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000445</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken341</tdc_id>
+        <rdfs:label>CRH-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CRH-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses CRH, and MYO16 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000446 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000446">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP LOC108588071</obo:PCL_0000100>
+        <id>pCL_0000446</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>THSD4-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000446</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken342</tdc_id>
+        <rdfs:label>THSD4-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a THSD4-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses LOC103791740, and THSD4 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000447 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000447">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP LOC108588539</obo:PCL_0000100>
+        <id>pCL_0000447</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC103787232-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000447</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken343</tdc_id>
+        <rdfs:label>LOC103787232-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a LOC103787232-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses LOC103787232, and LOC108588539 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000448 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000448">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP LOC108589153</obo:PCL_0000100>
+        <id>pCL_0000448</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ANO1-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000448</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken344</tdc_id>
+        <rdfs:label>ANO1-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a ANO1-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses ANO1, and KCNK13, and THSD7A mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000449 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000449">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP THSD7B</obo:PCL_0000100>
+        <id>pCL_0000449</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>LOC103788553-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000449</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken345</tdc_id>
+        <rdfs:label>LOC103788553-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a LOC103788553-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses LOC103788553, and THSD7B mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000450 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000450">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh VIP VAT1L</obo:PCL_0000100>
+        <id>pCL_0000450</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>TRPC4-expressing marmoset primary motor cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000450</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken346</tdc_id>
+        <rdfs:label>TRPC4-expressing marmoset primary motor cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a TRPC4-expressing marmoset primary motor cortex VIP GABAergic interneuron that selectively expresses LOC103795407, and TRPC4, and VIP mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000451 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000451">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129"/>
+        <obo:PCL_0000100>Micro TYROBP LOC103788313</obo:PCL_0000100>
+        <id>pCL_0000451</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>FYB-expressing marmoset primary motor cortex microglial cell</preferred_name>
+        <prefixIRI>pCL:0000451</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken347</tdc_id>
+        <rdfs:label>FYB-expressing marmoset primary motor cortex microglial cell</rdfs:label>
+        <skos:definition>is a FYB-expressing marmoset primary motor cortex microglial cell that selectively expresses FYB, and LOC103788313 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000452 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000452">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002453"/>
+        <obo:PCL_0000100>OPC PDGFRA VCAN</obo:PCL_0000100>
+        <id>pCL_0000452</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Pdgfra-expressing mouse primary motor cortex oligodendrocyte precursor cell</preferred_name>
+        <prefixIRI>pCL:0000452</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken348</tdc_id>
+        <rdfs:label>PDGFRA-expressing marmoset primary motor cortex oligodendrocyte precursor cell</rdfs:label>
+        <skos:definition>is a PDGFRA-expressing marmoset primary motor cortex oligodendrocyte precursor cell that selectively expresses PDGFRA, and VCAN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000453 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000453">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo OPALIN LOC103790018</obo:PCL_0000100>
+        <id>pCL_0000453</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>MOG-expressing marmoset primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000453</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken349</tdc_id>
+        <rdfs:label>MOG-expressing marmoset primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a MOG-expressing marmoset primary motor cortex oligodendrocyte that selectively expresses LOC103789268, and MOG mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000454 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000454">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo OPALIN MOBP</obo:PCL_0000100>
+        <id>pCL_0000454</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>ANLN-expressing marmoset primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000454</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken350</tdc_id>
+        <rdfs:label>ANLN-expressing marmoset primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a ANLN-expressing marmoset primary motor cortex oligodendrocyte that selectively expresses ANLN, and MOBP, and SEPP1, and SLC5A11 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000455 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000455">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo SLC1A3 LOC103793418</obo:PCL_0000100>
+        <id>pCL_0000455</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CEMIP-expressing marmoset primary motor cortex oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000455</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken351</tdc_id>
+        <rdfs:label>CEMIP-expressing marmoset primary motor cortex oligodendrocyte</rdfs:label>
+        <skos:definition>is a CEMIP-expressing marmoset primary motor cortex oligodendrocyte that selectively expresses CEMIP, and LAMA2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000456 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000456">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:2000043"/>
+        <obo:PCL_0000100>Peri SLC1A3 CHST3</obo:PCL_0000100>
+        <id>pCL_0000456</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CPM-expressing marmoset primary motor cortex brain pericyte</preferred_name>
+        <prefixIRI>pCL:0000456</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken352</tdc_id>
+        <rdfs:label>CPM-expressing marmoset primary motor cortex brain pericyte</rdfs:label>
+        <skos:definition>is a CPM-expressing marmoset primary motor cortex brain pericyte that selectively expresses CPM, and LOC100405319, and NOTCH3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000457 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000457">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:2000043"/>
+        <obo:PCL_0000100>Peri SLC1A3 EPSTI1</obo:PCL_0000100>
+        <id>pCL_0000457</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CPM-expressing marmoset primary motor cortex brain pericyte</preferred_name>
+        <prefixIRI>pCL:0000457</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken353</tdc_id>
+        <rdfs:label>COL4A3-expressing marmoset primary motor cortex brain pericyte</rdfs:label>
+        <skos:definition>is a COL4A3-expressing marmoset primary motor cortex brain pericyte that selectively expresses COL4A3, and PLXDC1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000458 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000458">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC PDGFRA C7</obo:PCL_0000100>
+        <id>pCL_0000458</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>C7-expressing marmoset primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000458</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken354</tdc_id>
+        <rdfs:label>C7-expressing marmoset primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a C7-expressing marmoset primary motor cortex vascular leptomeningeal cell that selectively expresses C7, and DCN mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000459 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000459">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC SLC1A3 CEMIP</obo:PCL_0000100>
+        <id>pCL_0000459</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLC9A2-expressing marmoset primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000459</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken355</tdc_id>
+        <rdfs:label>SLC9A2-expressing marmoset primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a SLC9A2-expressing marmoset primary motor cortex vascular leptomeningeal cell that selectively expresses LOC103789461, and SLC9A2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000460 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000460">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC SLC1A3 SLC13A3</obo:PCL_0000100>
+        <id>pCL_0000460</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>CARD11-expressing marmoset primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000460</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken356</tdc_id>
+        <rdfs:label>CARD11-expressing marmoset primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a CARD11-expressing marmoset primary motor cortex vascular leptomeningeal cell that selectively expresses CARD11, and SLC13A3 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000461 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000461">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL:0000359"/>
+        <obo:PCL_0000100>VLMC SLC1A3 SLC47A1</obo:PCL_0000100>
+        <id>pCL_0000461</id>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>SLC47A1-expressing marmoset primary motor cortex vascular leptomeningeal cell</preferred_name>
+        <prefixIRI>pCL:0000461</prefixIRI>
+        <species_id>NCBI:txid9483</species_id>
+        <species_source>common marmoset</species_source>
+        <tdc_id>Bakken357</tdc_id>
+        <rdfs:label>SLC47A1-expressing marmoset primary motor cortex vascular leptomeningeal cell</rdfs:label>
+        <skos:definition>is a SLC47A1-expressing marmoset primary motor cortex vascular leptomeningeal cell that selectively expresses SLC47A1 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PCL_0000465 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PCL_0000465">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000108"/>
+        <obo:PCL_0000100>L5/6 NP CT</obo:PCL_0000100>
+        <id>pCL_00000265</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001384"/>
+        <preferred_name>Grp-expressing mouse primary motor cortex glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:00000265</prefixIRI>
+        <species_id>NCBI:txid10090</species_id>
+        <species_source>mouse</species_source>
+        <tdc_id>Bakken165</tdc_id>
+        <rdfs:label>Grp-expressing mouse primary motor cortex glutamatergic neuron</rdfs:label>
+        <skos:definition>is a Grp-expressing mouse primary motor cortical layer 5/6 non-pyramidal glutamatergic neuron that selectively expresses Grp, and Rxfp1, and Tshz2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001384 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001384">
+        <rdfs:label>primary motor cortex</rdfs:label>
+        <skos:definition>The part of the cerebral cortex that receives projections from the motor thalamus and which projects to motor neurons in the brainstem and spinal cord. The motor cortex corresponds to Brodmann&apos;s area 4 (MM). The primary motor cortex, or M1, is located on the precentral gyrus and on the anterior paracentral lobule on the medial surface of the brain. Of the three motor cortex areas, stimulation of the primary motor cortex requires the least amount of electrical current to elicit a movement. http://neuroscience.uth.tmc.edu/s3/chapter03.html</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL:0000359 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL:0000359">
+        <id>CL:0000359</id>
+        <prefixIRI>CL:0000359</prefixIRI>
+        <rdfs:label>vascular associated smooth muscle cell</rdfs:label>
+        <skos:definition>A smooth muscle cell assocatiated with the vasculature.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL:2000043 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL:2000043">
+        <id>CL:2000043</id>
+        <prefixIRI>CL:2000043</prefixIRI>
+        <rdfs:label>brain pericyte</rdfs:label>
+        <skos:definition>Any pericyte cell that is part of a brain.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128">
+        <rdfs:label>oligodendrocyte</rdfs:label>
+        <skos:definition>A class of large neuroglial (macroglial) cells in the central nervous system. Form the insulating myelin sheath of axons in the central nervous system./Oligodendrocytes are reportedly MDP-positive and CD4-negative.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129">
+        <rdfs:label>microglial cell</rdfs:label>
+        <skos:definition>A central nervous system macrophage found in the parenchyma of the central nervous system. Marker include CD11b-positive, F4/80-positive, and CD68-positive./Markers: Mouse: CD11b+, F4/80+, CD68+. They represent ~12% of the cells in the CNS, but they are not uniformly distributed within the CNS. A normal adult mouse brain has approximately 3.5x10e6 microglia. Microglia are also reportedly CD3-negative, CD4-positive, CD8-negative, CD11b-positive, CD11c-high, CD14-negative, CD19-negative, CD45-low, CD56-negative, CD163-negative, CD200R-positive, CD281-positive, CD282-positive, CD283-positive, CD284-positive, CD285-positive, CD286-positive, CD287-positive, CD288-positive, CD289-positive, Gr1-negative, nestin-positive, and PU.1-positive.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000679 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000679">
+        <rdfs:label>glutamatergic neuron</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002453 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002453">
+        <rdfs:label>oligodendrocyte precursor cell</rdfs:label>
+        <skos:definition>The cell type from which oligodendrocytes develop. This cell originates from multiple structures within the developing brain including the medial ganglion eminence and the lateral ganglionic eminence. These cells migrate throughout the central nervous system and persist into adulthood where they play an important role in remyelination of injured neurons.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605">
+        <rdfs:label>astrocyte of the cerebral cortex</rdfs:label>
+        <skos:definition>An astrocyte of the cerebral cortex.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_0010011 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0010011">
+        <rdfs:label>cerebral cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>a GABAergic interneuron that is part_of a cerebral cortex</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602">
+        <rdfs:label>cerebral cortex endothelial cell</rdfs:label>
+        <skos:definition>Endothelial cells forming the walls of the capillaries within the cerebral cortex.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771">
+        <rdfs:label>middle temporal gyrus</rdfs:label>
+        <skos:definition>Component of the temporal lobe, lateral aspect. The rostral boundary is the rostral extent of the superior temporal sulcus whereas the caudal boundary is the temporo-occipital incisure on the cortical surface. The superior temporal sulcus is the medial boundary and the inferior temporal sulcus is the lateral boundary (Christine Fennema-Notestine).</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000001 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000001">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000078"/>
+        <obo:PCL_0000100>Inh L1-2 PAX6 CDH12</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000001</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>TGFBR2-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000001</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge1</tdc_id>
+        <rdfs:label>TGFBR2-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses TGFBR2|HGNC_11773, LOC101927870 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000002 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000002">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000078"/>
+        <obo:PCL_0000100>Inh L1-2 PAX6 TNFAIP8L3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000002</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SP8-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000002</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge2</tdc_id>
+        <rdfs:label>SP8-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SP8|HGNC_19196, LINC01497|HGNC_51163 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000003 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000003">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1 LAMP5 NMBR</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000003</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>NDNF-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000003</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge3</tdc_id>
+        <rdfs:label>NDNF-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses NDNF|HGNC_26256, SV2C|HGNC_30670 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000004 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000004">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1-4 LAMP5 LCP2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000004</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>KIT-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000004</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge4</tdc_id>
+        <rdfs:label>KIT-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses KIT|HGNC_6342, CPLX3|HGNC_27652 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000005 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000005">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L1-2 LAMP5 DBP</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000005</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CPLX3-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000005</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge5</tdc_id>
+        <rdfs:label>CPLX3-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses CPLX3|HGNC_27652, CBLN4|HGNC_16231 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000006 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000006">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000113"/>
+        <obo:PCL_0000100>Inh L2-6 LAMP5 CA1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000006</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>EYA4-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000006</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge6</tdc_id>
+        <rdfs:label>EYA4-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses EYA4|HGNC_3522, TMEM255A|HGNC_26086 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000007 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1 SST CHRNA4</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <id>pCL_0000007</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ANKFN1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000007</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge7</tdc_id>
+        <rdfs:label>ANKFN1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses ANKFN1|HGNC_26766, SEMA3C|HGNC_10725, CXCL14|HGNC_10640 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000008 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000008">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000078"/>
+        <obo:PCL_0000100>Inh L1-2 ADARB2 MC4R</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000008</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ARHGAP36-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000008</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge8</tdc_id>
+        <rdfs:label>ARHGAP36-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses ARHGAP36|HGNC_26388, ADAM33|HGNC_15478 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000009 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000009">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 SST BAGE2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000009</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>BAGE2-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000009</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge9</tdc_id>
+        <rdfs:label>BAGE2-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a FBXL7-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses BAGE2|HGNC_15723, LOC105377436 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000010 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000010">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP SYT6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000010</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CNR1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000010</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge10</tdc_id>
+        <rdfs:label>CNR1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses CNR1|HGNC_2159, PLCXD3|HGNC_31822 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000011 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000011">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 VIP TSPAN12</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000011</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>DCN-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000011</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge11</tdc_id>
+        <rdfs:label>DCN-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses DCN|HGNC_2705, LINC01539|HGNC_51307 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000012 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000012">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-4 VIP CHRNA6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000012</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CCDC141-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000012</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge12</tdc_id>
+        <rdfs:label>CCDC141-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LOC101928923, CCDC141|HGNC_26821 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000013 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP ADAMTSL1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000013</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>DACH2-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000013</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge13</tdc_id>
+        <rdfs:label>DACH2-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses DACH2|HGNC_16814, PCDH18|HGNC_14268 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000014 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-4 VIP PENK</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000014</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>EGFEM1P-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000014</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge14</tdc_id>
+        <rdfs:label>EGFEM1P-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses EGFEM1P|HGNC_25149, LOC105371331 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000015 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000015">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-6 VIP QPCT</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000015</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>IGFBP7-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000015</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge15</tdc_id>
+        <rdfs:label>IGFBP7-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses PCP4|HGNC_8742, IGFBP7|HGNC_5476 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000016 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000016">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L3-6 VIP HS3ST3A1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000016</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>IQGAP2-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000016</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge16</tdc_id>
+        <rdfs:label>IQGAP2-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses IQGAP2|HGNC_6111, ABI3BP|HGNC_17265 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000017 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 VIP PCDH20</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000017</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ANGPT1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000017</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge17</tdc_id>
+        <rdfs:label>ANGPT1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses ANGPT1|HGNC_484, VIP|HGNC_12693 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000018 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-5 VIP SERPINF1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000018</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>TSHZ2-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000018</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge18</tdc_id>
+        <rdfs:label>TSHZ2-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses TAC3|HGNC_11521, TSHZ2|HGNC_13010, LINC01583|HGNC_51425 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000019 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000019">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-5 VIP TYR</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000019</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>COL15A1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000019</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge19</tdc_id>
+        <rdfs:label>COL15A1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses TAC3|HGNC_11521, COL15A1|HGNC_2192 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000020 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP CHRM2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000020</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LOC100421401-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000020</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge20</tdc_id>
+        <rdfs:label>LOC100421401-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LOC100421401, LOC101060145 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000021 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000021">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-4 VIP CBLN1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000021</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>HTR2C-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000021</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge21</tdc_id>
+        <rdfs:label>HTR2C-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses HTR2C|HGNC_5295, MME|HGNC_7154 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000022 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000022">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP CCDC184</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000022</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>KCNH8-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000022</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge22</tdc_id>
+        <rdfs:label>KCNH8-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses KCNH8|HGNC_18864, SCML4|HGNC_21397 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000023 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000023">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-3 VIP GGH</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000023</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>GGH-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000023</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge23</tdc_id>
+        <rdfs:label>GGH-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses GGH|HGNC_4248, LOC105375473 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000024 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000024">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-2 VIP LBH</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000024</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>C18orf42-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000024</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge24</tdc_id>
+        <rdfs:label>C18orf42-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses C18orf42|HGNC_28285, LOC105379146 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000025 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000025">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-3 VIP CASC6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000025</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LRRC63-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000025</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge25</tdc_id>
+        <rdfs:label>LRRC63-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LRRC63|HGNC_34296, CASC6|HGNC_49076, LOC105370456 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000026 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L2-4 VIP SPAG17</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000026</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SLC7A11-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000026</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge26</tdc_id>
+        <rdfs:label>SLC7A11-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SLC7A11|HGNC_11059, LINC00836|HGNC_44915 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000027 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000027">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000118"/>
+        <obo:PCL_0000100>Inh L1-4 VIP OPRM1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000027</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>PCP4|LINC01583-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000027</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge27</tdc_id>
+        <rdfs:label>PCP4-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a VIP-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses PCP4|HGNC_8742, LINC01583|HGNC_51425, SLC22A3|HGNC_10967 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000028 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000028">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000116"/>
+        <obo:PCL_0000100>Inh L3-6 SST NPY</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000028</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>NPY-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000028</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge28</tdc_id>
+        <rdfs:label>NPY-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GAD1-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses NPY|HGNC_7955 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000029 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000029">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L3-6 SST HPGD</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000029</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>HPGD-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000029</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge29</tdc_id>
+        <rdfs:label>HPGD-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses HPGD|HGNC_5154, FAM89A|HGNC_25057, MOXD1|HGNC_21063 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000030 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000030">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L4-6 SST B3GAT2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000030</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>NMU-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000030</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge30</tdc_id>
+        <rdfs:label>NMU-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses NMU|HGNC_7859, FREM1|HGNC_23399, TAC3|HGNC_11521 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000031 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000031">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST KLHDC8A</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000031</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LOC100996671-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000031</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge31</tdc_id>
+        <rdfs:label>LOC100996671-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LOC100996671, LOC105377701 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000032 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST NPM1P10</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000032</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SPON1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000032</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge32</tdc_id>
+        <rdfs:label>SPON1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SPON1|HGNC_11252, FBN2|HGNC_3604 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000033 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000033">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L4-6 SST GXYLT2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000033</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>QRFPR-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000033</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge33</tdc_id>
+        <rdfs:label>QRFPR-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses QRFPR|HGNC_15565, SLC17A8|HGNC_20151, LOC101929667 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000034 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000034">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L4-5 SST STK32A</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000034</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>STK32A-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000034</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge34</tdc_id>
+        <rdfs:label>STK32A-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SLC9A2|HGNC_11072, STK32A|HGNC_28317 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000035 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000035">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L1-3 SST CALB1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000035</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LOC101929028-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000035</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge35</tdc_id>
+        <rdfs:label>LOC101929028-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LOC101929028 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000036 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000036">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L3-5 SST ADGRG6</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000036</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ADGRG6-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000036</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge36</tdc_id>
+        <rdfs:label>ADGRG6-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses ADGRG6|HGNC_13841, PROM1|HGNC_9454 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000037 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000037">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L2-4 SST FRZB</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000037</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>EYS-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000037</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge37</tdc_id>
+        <rdfs:label>EYS-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses EYS|HGNC_21555, HPSE2|HGNC_18374, NOS1|HGNC_7872, MYO5B|HGNC_7603 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000038 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000038">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000117"/>
+        <obo:PCL_0000100>Inh L5-6 SST TH</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000038</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>TH-expressing human-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000038</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge38</tdc_id>
+        <rdfs:label>TH-expressing human-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a SST-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LOC102724957, TH|HGNC_11782 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000039 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000039">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 LHX6 GLP1R</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000039</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SEMA3C-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000039</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge39</tdc_id>
+        <rdfs:label>SEMA3C-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses CPED1|HGNC_26159, SEMA3C|HGNC_10725, BCHE|HGNC_983 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000040 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000040">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 PVALB LGR5</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000040</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ANKRD34B-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000040</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge40</tdc_id>
+        <rdfs:label>ANKRD34B-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses ANKRD34B|HGNC_33736, LOC401478, CPED1|HGNC_26159 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000041 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000041">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L4-5 PVALB MEPE</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000041</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>MEPE-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000041</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge41</tdc_id>
+        <rdfs:label>MEPE-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SPP1|HGNC_11255, HGF|HGNC_4893, MEPE|HGNC_13361 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000042 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000042">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L2-4 PVALB WFDC2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000042</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SLC9A9-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000042</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge42</tdc_id>
+        <rdfs:label>SLC9A9-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SLC9A9|HGNC_20653, TAC1|HGNC_11517 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000043 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000043">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L4-6 PVALB SULF1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000043</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SULF1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000043</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge43</tdc_id>
+        <rdfs:label>SULF1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses SULF1|HGNC_20391, CPED1|HGNC_26159 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000044 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000044">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L5-6 SST MIR548F2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000044</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LYPD6-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000044</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge44</tdc_id>
+        <rdfs:label>LYPD6-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses LYPD6|HGNC_28751, PAWR|HGNC_8614, GPC5|HGNC_4453 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000045 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000045">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PCL_0000114"/>
+        <obo:PCL_0000100>Inh L2-5 PVALB SCUBE3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000045</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>COL15A1-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000045</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge45</tdc_id>
+        <rdfs:label>COL15A1-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a PVALB-expressing human cerebral cortex MTG GABAergic interneuron that selectively expresses COL15A1|HGNC_2192, LOC401478 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000046 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000046">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000091"/>
+        <obo:PCL_0000100>Exc L2 LAMP5 LTK</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000046</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CBLN2-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000046</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge46</tdc_id>
+        <rdfs:label>CBLN2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CUX2-expressing human MTG Glutamatergic neuron that selectively expresses LINC01500|HGNC_51166, CBLN2|HGNC_1544 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000047 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000047">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000091"/>
+        <obo:PCL_0000100>Exc L2-4 LINC00507 GLP2R</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000047</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>PENK-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000047</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge47</tdc_id>
+        <rdfs:label>PENK-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CUX2-expressing human MTG Glutamatergic neuron that selectively expresses PENK|HGNC_8831, CALCRL|HGNC_16709, MOXD1|HGNC_21063 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000048 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000048">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000091"/>
+        <obo:PCL_0000100>Exc L2-3 LINC00507 FREM3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <id>pCL_0000048</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>PALMD-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000048</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge48</tdc_id>
+        <rdfs:label>PALMD-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a CUX2-expressing human MTG Glutamatergic neuron that selectively expresses PALMD|HGNC_15846, CUX2|HGNC_19347 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000049 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000049">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <obo:PCL_0000100>Exc L5-6 THEMIS C1QL3</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000049</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>PXDN-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000049</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge49</tdc_id>
+        <rdfs:label>PXDN-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses LINC00343|HGNC_42500, PXDN|HGNC_14966, THEMIS|HGNC_21569 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000050 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000050">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093"/>
+        <obo:PCL_0000100>Exc L3-4 RORB CARM1P1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000050</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CCDC68-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000050</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge50</tdc_id>
+        <rdfs:label>CCDC68-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COBLL1-expressing human MTG Glutamatergic neuron that selectively expresses CCDC68|HGNC_24350, CARM1P1|HGNC_23392, PRSS12|HGNC_9477 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000051 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000051">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093"/>
+        <obo:PCL_0000100>Exc L3-5 RORB ESR1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000051</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ANXA1-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000051</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge51</tdc_id>
+        <rdfs:label>ANXA1-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COBLL1-expressing human MTG Glutamatergic neuron that selectively expresses ANXA1|HGNC_533, LOC105371677 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000052 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000052">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093"/>
+        <obo:PCL_0000100>Exc L3-5 RORB COL22A1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000052</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>RMST-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000052</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge52</tdc_id>
+        <rdfs:label>RMST-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COBLL1-expressing human MTG Glutamatergic neuron that selectively expresses RMST|HGNC_29893, MME|HGNC_7154 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000053 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000053">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093"/>
+        <obo:PCL_0000100>Exc L3-5 RORB FILIP1L</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000053</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CUX2|NTNG-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000053</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge53</tdc_id>
+        <rdfs:label>CUX2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COBLL1-expressing human MTG Glutamatergic neuron that selectively expresses CUX2|HGNC_19347, NTNG1|HGNC_23319, COL5A2|HGNC_2210, LOC101928196 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000054 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000054">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093"/>
+        <obo:PCL_0000100>Exc L3-5 RORB TWIST2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000054</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>TWIST2-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000054</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge54</tdc_id>
+        <rdfs:label>TWIST2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a COBLL1-expressing human MTG Glutamatergic neuron that selectively expresses TWIST2|HGNC_20670, LOC101927281, CCDC168|HGNC_26851 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000055 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000055">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094"/>
+        <obo:PCL_0000100>Exc L4-5 RORB FOLH1B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000055</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>RBM20-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000055</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge55</tdc_id>
+        <rdfs:label>RBM20-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TRABD2A-expressing human MTG Glutamatergic neuron that selectively expresses LOC101927835, RBM20|HGNC_27424, NPY2R|HGNC_7957 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000056 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000056">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094"/>
+        <obo:PCL_0000100>Exc L4-6 RORB SEMA3E</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000056</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>RPRM-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000056</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge56</tdc_id>
+        <rdfs:label>RPRM-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TRABD2A-expressing human MTG Glutamatergic neuron that selectively expresses RPRM|HGNC_24201, LOC101928622 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000057 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000057">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094"/>
+        <obo:PCL_0000100>Exc L4-5 RORB DAPK2</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000057</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>BARX2-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000057</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge57</tdc_id>
+        <rdfs:label>BARX2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TRABD2A-expressing human MTG Glutamatergic neuron that selectively expresses LINC01179|HGNC_49556, BARX2|HGNC_956, LOC105374971 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000058 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000058">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094"/>
+        <obo:PCL_0000100>Exc L5-6 RORB TTC12</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000058</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>TNNT2-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000058</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge58</tdc_id>
+        <rdfs:label>TNNT2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TRABD2A-expressing human MTG Glutamatergic neuron that selectively expresses TNNT2|HGNC_11949, LOC105371833, NPFFR2|HGNC_4525 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000059 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000059">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094"/>
+        <obo:PCL_0000100>Exc L4-6 RORB C1R</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000059</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ITGA11-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000059</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge59</tdc_id>
+        <rdfs:label>ITGA11-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a TRABD2A-expressing human MTG Glutamatergic neuron that selectively expresses ITGA11|HGNC_6136, PKD2L1|HGNC_9011, MEGF10|HGNC_29634 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000060 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000060">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <obo:PCL_0000100>Exc L4-5 FEZF2 SCN4B</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000060</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LOC105376457-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000060</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge60</tdc_id>
+        <rdfs:label>LOC105376457-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses LOC105376457, LOC105378657 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000061 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000061">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000095"/>
+        <obo:PCL_0000100>Exc L5-6 THEMIS DCSTAMP</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000061</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>LOC101928196-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000061</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge61</tdc_id>
+        <rdfs:label>LOC101928196-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a OLFML2B-expressing human MTG Glutamatergic neuron that selectively expresses LOC101928196, LOC105378486 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000062 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000062">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000095"/>
+        <obo:PCL_0000100>Exc L5-6 THEMIS CRABP1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000062</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SNTB1-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000062</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge62</tdc_id>
+        <rdfs:label>SNTB1-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SNTB1-expressing human MTG Glutamatergic neuron that selectively expresses OLFML2B|HGNC_24558, SNTB1|HGNC_11168 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000063 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000063">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000095"/>
+        <obo:PCL_0000100>Exc L5-6 THEMIS FGF10</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000063</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>GAS2L3-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000063</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge63</tdc_id>
+        <rdfs:label>GAS2L3-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a OLFML2B-expressing human MTG Glutamatergic neuron that selectively expresses LOC101928964, GAS2L3|HGNC_27475 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000064 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000064">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <obo:PCL_0000100>Exc L4-6 FEZF2 IL26</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000064</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>IL26-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000064</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge64</tdc_id>
+        <rdfs:label>IL26-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses IFNG_AS1|HGNC_43910, IL26|HGNC_17119 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000065 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000065">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 ABO</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000065</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SULF1-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000065</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge65</tdc_id>
+        <rdfs:label>SULF1-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EGFEM1P-expressing human MTG Glutamatergic neuron that selectively expresses SULF1|HGNC_20391, ADAMTSL1|HGNC_14632 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000066 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000066">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 SCUBE1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000066</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>PIK3C2G-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000066</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge66</tdc_id>
+        <rdfs:label>PIK3C2G-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EGFEM1P-expressing human MTG Glutamatergic neuron that selectively expresses LOC105379054, PIK3C2G|HGNC_8973 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000067 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000067">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 IL15</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000067</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>NR4A2-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000067</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge67</tdc_id>
+        <rdfs:label>NR4A2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EGFEM1P-expressing human MTG Glutamatergic neuron that selectively expresses NR4A2|HGNC_7981, NPNT|HGNC_27405, ERG|HGNC_3446 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000068 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000068">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096"/>
+        <obo:PCL_0000100>Exc L6 FEZF2 OR2T8</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000068</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SLC15A5-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000068</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge68</tdc_id>
+        <rdfs:label>SLC15A5-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EGFEM1P-expressing human MTG Glutamatergic neuron that selectively expresses SLC15A5|HGNC_33455, IGFBP3|HGNC_5472, SLITRK6|HGNC_23503, PCOLCE2|HGNC_8739 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000069 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000069">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096"/>
+        <obo:PCL_0000100>Exc L5-6 FEZF2 EFTUD1P1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000069</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>NPFFR2-expressing human cerebral cortex MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000069</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge69</tdc_id>
+        <rdfs:label>NPFFR2-expressing human cerebral cortex MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a EGFEM1P-expressing human MTG Glutamatergic neuron that selectively expresses NPFFR2|HGNC_4525, LOC105377183 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000070 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000070">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002453"/>
+        <obo:PCL_0000100>OPC L1-6 PDGFRA</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000070</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>PCDH15-expressing human MTG Oligodendrocyte precursor cell</preferred_name>
+        <prefixIRI>pCL:0000070</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge70</tdc_id>
+        <rdfs:label>PCDH15-expressing human MTG Oligodendrocyte precursor cell</rdfs:label>
+        <skos:definition>is a human MTG Oligodendrocyte precursor cell that selectively expresses PCDH15|HGNC_14674, PDGFRA|HGNC_8803 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000071 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000071">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000088"/>
+        <obo:PCL_0000100>Astro L1-6 FGFR3 SLC14A1</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000071</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>SLC1A3-expressing human MTG astrocyte
+
+4/12/2020
+Astro L1-6 FGFR3 SLC14A1</preferred_name>
+        <prefixIRI>pCL:0000071</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge71</tdc_id>
+        <rdfs:label>SLC1A3-expressing human MTG astrocyte</rdfs:label>
+        <skos:definition>is a FGFR3-expressing human MTG astrocyte that selectively expresses LOC105376917, SLC1A3|HGNC_10941 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000072 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000072">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000088"/>
+        <obo:PCL_0000100>Astro L1-2 FGFR3 GFAP</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <id>pCL_0000072</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>MT1F-expressing human MTG astrocyte
+
+04/12/20
+Astro L1-2 FGFR3 GFAP</preferred_name>
+        <prefixIRI>pCL:0000072</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge72</tdc_id>
+        <rdfs:label>MT1F-expressing human MTG astrocyte</rdfs:label>
+        <skos:definition>is a FGFR3-expressing human MTG astrocyte that selectively expresses MT1F|HGNC_7398, ID3|HGNC_5362 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000073 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000073">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000128"/>
+        <obo:PCL_0000100>Oligo L1-6 OPALIN</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000073</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>ENPP2-expressing human MTG Oligodendrocyte</preferred_name>
+        <prefixIRI>pCL:0000073</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge73</tdc_id>
+        <rdfs:label>ENPP2-expressing human MTG oligodendrocyte</rdfs:label>
+        <skos:definition>is a human MTG Oligodendrocyte that selectively expresses ENPP2|HGNC_3357, CERCAM|HGNC_23723 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000074 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000074">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_1001602"/>
+        <obo:PCL_0000100>Endo L2-6 NOSTRIN</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000074</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>EMCN-expressing human cerebral cortex MTG endothelial cell</preferred_name>
+        <prefixIRI>pCL:0000074</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge74</tdc_id>
+        <rdfs:label>EMCN-expressing human cerebral cortex MTG endothelial cell</rdfs:label>
+        <skos:definition>is a human cerebral cortex MTG endothelial cell that selectively expresses EMCN|HGNC_16041 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000075 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000075">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000129"/>
+        <obo:PCL_0000100>Micro L1-6 TYROBP</obo:PCL_0000100>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000075</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CSF1R-expressing human MTG Microglial cell</preferred_name>
+        <prefixIRI>pCL:0000075</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <tdc_id>Hodge75</tdc_id>
+        <rdfs:label>CSF1R-expressing human MTG Microglial cell</rdfs:label>
+        <skos:definition>is a human MTG Microglial cell that selectively expresses CSF1R|HGNC_2433, APBB1IP|HGNC_17379 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000076 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000076">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0010011"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000076</id>
+        <neuron_type>GABAergic</neuron_type>
+        <preferred_name>GAD1-expressing cerebral cortex GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000076</prefixIRI>
+        <rdfs:label>GAD1-expressing cerebral cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a cerebral cortex  GABAergic interneuron that selectively expresses GAD1 and GAD2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0000679"/>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000077</id>
+        <neuron_type>glutamatergic</neuron_type>
+        <preferred_name>SLC17A7-expressing glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000077</prefixIRI>
+        <rdfs:label>SLC17A7-expressing glutamatergic neuron</rdfs:label>
+        <skos:definition>is a glutamatergic neuron that selectively expresses SLC17A7, SATB2 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000078 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000078">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000078</id>
+        <neuron_type>GABAergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>FBXL7-expressing human cerebral cortex MTG GABAergic interneuron</preferred_name>
+        <prefixIRI>pCL:0000078</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>FBXL7-expressing human cerebral cortex MTG GABAergic interneuron</rdfs:label>
+        <skos:definition>is a CXCL14-expressing human MTG Glutamatergic neuron that selectively expresses FBXL7|HGNC_13604, SV2C|HGNC_30670 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000079 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000079">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000076"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000079</id>
+        <neuron_type>GABAergic</neuron_type>
+        <prefixIRI>pCL:0000079</prefixIRI>
+        <rdfs:label>MGE-derived cerebral cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GAD1-expressing human cerebral cortex MTG GABAergic interneuron derived from the medial ganglionic eminence (UBERON_0004024)</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000088 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000088">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#CL_0002605"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000088</id>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>FGFR3-expressing human MTG astrocyte</preferred_name>
+        <prefixIRI>pCL:0000088</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>FGFR3-expressing human MTG astrocyte</rdfs:label>
+        <skos:definition>is a human MTG Astrocyte of the cerebral cortex that selectively expresses FGFR3|HGNC_3690 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000091 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000091">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <id>pCL_0000091</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>CUX2-expressing human MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000091</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>CUX2-expressing human MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses LINC00507|HGNC_43558, CUX2|HGNC_19347 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000092 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000092">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000092</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>RORB-expressing human MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000092</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>RORB-expressing human MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses LOC105374972 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000093">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000092"/>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <id>pCL_0000093</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>COBLL1-expressing human MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000093</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>COBLL1-expressing human MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a RORB-expressing human MTG Glutamatergic neuron that selectively expresses LOC101927281, COBLL1|HGNC_23571 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000094">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000092"/>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000094</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>TRABD2A-expressing human MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000094</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>TRABD2A-expressing human MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a RORB-expressing human MTG Glutamatergic neuron that selectively expresses TRABD2A|HGNC_27013, LOC105374971 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000095 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000095">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000095</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>OLFML2B-expressing human MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000095</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>OLFML2B-expressing human MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses OLFML2B|HGNC_24558, SMYD1|HGNC_20986 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000096">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000077"/>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000096</id>
+        <neuron_type>Glutamatergic</neuron_type>
+        <part_of rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_0002771"/>
+        <preferred_name>EGFEM1P-expressing human MTG Glutamatergic neuron</preferred_name>
+        <prefixIRI>pCL:0000096</prefixIRI>
+        <species_id>NCBI:txid9606</species_id>
+        <species_source>Human</species_source>
+        <rdfs:label>EGFEM1P-expressing human MTG Glutamatergic neuron</rdfs:label>
+        <skos:definition>is a SLC17A7-expressing human MTG Glutamatergic neuron that selectively expresses EGFEM1P|HGNC_25149, ADAMTSL1|HGNC_14632 mRNAs</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097 -->
+
+    <owl:Class rdf:about="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000097">
+        <rdfs:subClassOf rdf:resource="http://www.jcvi.org/framework/nsf2_full_mtg#pCL_0000076"/>
+        <has_soma_location_in>cortical_layer1</has_soma_location_in>
+        <has_soma_location_in>cortical_layer2</has_soma_location_in>
+        <has_soma_location_in>cortical_layer3</has_soma_location_in>
+        <has_soma_location_in>cortical_layer4</has_soma_location_in>
+        <has_soma_location_in>cortical_layer5</has_soma_location_in>
+        <has_soma_location_in>cortical_layer6</has_soma_location_in>
+        <id>pCL_0000097</id>
+        <neuron_type>GABAergic</neuron_type>
+        <prefixIRI>pCL:0000097</prefixIRI>
+        <rdfs:label>CGE-derived cerebral cortex GABAergic interneuron</rdfs:label>
+        <skos:definition>is a GAD1-expressing human cerebral cortex MTG GABAergic interneuron derived from the caudal ganglionic eminence (UBERON:0004026)</skos:definition>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+


### PR DESCRIPTION
Adding the Provisional Cell Ontology (released 04/26/2020) to terra-core-data-model.
The file was downloaded in .owl format, opened in Protege, and saved to an RDF format.
A comment was added to indicate the source of the file.